### PR TITLE
show stack trace when errors occur in integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby] # Windows doe
 gem 'uglifier', '>= 1.3.0'
 
 group :development, :integration, :test do
+  gem 'better_errors'
   gem 'binding_of_caller'
   gem 'bixby', '~> 1.0.0'
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,10 @@ GEM
     ast (2.4.0)
     bcp47 (0.3.3)
       i18n
+    better_errors (2.5.0)
+      coderay (>= 1.0.0)
+      erubi (>= 1.0.0)
+      rack (>= 0.9.0)
     bindex (0.5.0)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
@@ -74,6 +78,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (>= 2.0, < 4.0)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -432,6 +437,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  better_errors
   binding_of_caller
   bixby (~> 1.0.0)
   byebug

--- a/config/environments/integration.rb
+++ b/config/environments/integration.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local       = true
   config.action_controller.perform_caching = true
 
   # THIS BLOCK IS NOT IN ESMIS PRODUCTION


### PR DESCRIPTION
Show stacktrace and command line in the browser instead of the Something Went Wrong modal when error occur in integration.  This will allow for easier debugging on AWS on the integration machine.