### PR TITLE
Add link to API Doc in main nav menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ reports
 .env
 .env.*
 !.env.example
+
+# Ignore generated gruff graphs
+app/assets/images/qa_server/charts/*.png

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'dotenv-deployment'
 gem 'dotenv-rails'
 
 # Required gems for QA and linked data access
-gem 'qa_server', '1.0.0'
+gem 'qa_server', '1.1.0'
 gem 'qa', github: 'samvera/questioning_authority', branch: 'min_context'
 gem 'linkeddata'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,7 +221,7 @@ GEM
     powerpack (0.1.2)
     public_suffix (3.0.3)
     puma (3.12.0)
-    qa_server (1.0.0)
+    qa_server (1.1.0)
       gruff
       rails (~> 5.0)
     rack (2.0.5)
@@ -458,7 +458,7 @@ DEPENDENCIES
   mysql2
   puma (~> 3.7)
   qa!
-  qa_server (= 1.0.0)
+  qa_server (= 1.1.0)
   rails (~> 5.1.6)
   rails-controller-testing
   rspec-activemodel-mocks

--- a/config/initializers/qa_server.rb
+++ b/config/initializers/qa_server.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+QaServer.config do |config|
+  # Displays a graph of historical test data when true
+  # @param [Boolean] display history graph when true
+  config.display_historical_graph = false
+
+  # Displays a datatable of historical test data when true
+  # @param [Boolean] display history datatable when true
+  config.display_historical_datatable = true
+
+  # Additional menu items to add to the main navigation menu's set of left justified menu items
+  # @param [Array<Hash<String,String>>] array of menu items to append with hash label: is menu item label to display and hash url: is URL for the menu item link
+  config.navmenu_extra_leftitems = [
+    { label: 'API Documentation', url: '/qa/apidoc/' }
+  ]
+end

--- a/public/qa/apidoc/apidoc.json
+++ b/public/qa/apidoc/apidoc.json
@@ -10,15 +10,23 @@
   },
   "servers": [
     {
-      "url": "http://{site_host}/{apiBase}",
+      "url": "https://lookup.ld4l.org/authorities",
+      "description": "LD4L Lookup - QA v2.1 API Server",
+    },
+    {
+      "url": "http://localhost:3000/authorities",
+      "description": "QA v2.1 API Server",
+    },
+    {
+      "url": "http://{site_host}/{qa_engine_mount}",
       "description": "QA v2.1 API Server",
       "variables": {
         "site_host": {
           "default": "localhost:3000",
           "description": ""
         },
-        "apiBase": {
-          "default": "qa"
+        "qa_engine_mount": {
+          "default": "authorities"
         }
       }
     }
@@ -176,7 +184,7 @@
     },
     "/search/linked_data/{vocab}/{subauthority}": {
       "get": {
-        "summary": "Send a query string to a subauthority in an authority and return search results.",
+        "summary": "Send a query string to a subauthority in an authority and return search results.  Parameters are typical examples.  Actual parameters are driven by the authority's config file.",
         "operationId": "GET_searchSubauthority",
         "tags": [
           "Search Query"

--- a/public/qa/apidoc/index.html
+++ b/public/qa/apidoc/index.html
@@ -31,7 +31,7 @@
   </head>
 
   <body>
-  <a style="padding-left: 15px; font-family: Helvetica; color: #303d4d" href="javascript:history.back()">Go Back</a>
+  <a style="padding-left: 15px; font-family: Helvetica; color: #303d4d" href="/">Home</a>
   <div id="swagger-ui"></div>
 
     <script src="./swagger-ui-bundle.js"> </script>


### PR DESCRIPTION
API DOC changes
* include link to API DOC in main nav menu
* change Go Back link to Home link
* fix server selection variables
* add production server to servers list and set to default

Other changes
* update ld4p/qa_server to 1.1.0
* shows status history as datatable instead of graph