### PR TITLE
remove golden notebook from cornell sharevde tests

### DIFF
--- a/config/authorities/linked_data/scenarios/sharevde_cornell_work_ld4l_cache_validation.yml
+++ b/config/authorities/linked_data/scenarios/sharevde_cornell_work_ld4l_cache_validation.yml
@@ -4,8 +4,8 @@ authority:
 search:
   -
     query: 'mark twain'
-  -
-    query: 'golden notebook'
+#  -
+#    query: 'golden notebook'
 term:
   -
     identifier: 'http://share-vde.org/sharevde/rdfBibframe/Work/1635833'


### PR DESCRIPTION
Getting data for The Golden Notebook takes too long and times out the tests.  It is not a good connection test.  28M of data are returned by this query.