### PR TITLE
minor tweaks to wikidata, discogs, and bioportal mesh

### DIFF
--- a/app/authorities/qa/authorities/wikidata/generic_authority.rb
+++ b/app/authorities/qa/authorities/wikidata/generic_authority.rb
@@ -63,6 +63,7 @@ module Qa::Authorities
 
       def extended_context(doc)
         extended_context = []
+        extended_context << { property: 'label', value: doc['label'] } if doc.key? 'label'
         extended_context << { property: 'title', value: doc['title'] } if doc.key? 'title'
         extended_context << { property: 'description', value: doc['description'] } if doc.key? 'description'
         extended_context

--- a/app/prepends/prepended_presenters/authority_list_presenter.rb
+++ b/app/prepends/prepended_presenters/authority_list_presenter.rb
@@ -51,7 +51,7 @@ module PrependedPresenters::AuthorityListPresenter
      :authority_name=>:DISCOGS,
      :subauthority_name=>"master",
      :service=>"NOT linked data",
-     :action=>"search",
+     :action=>"term",
      :url=>"authorities/show/discogs/master/144098",
      :expected=>nil,
      :actual=>nil,

--- a/config/authorities/linked_data/DISABLED/scenarios/mesh_bioportal_ld4l_cache_validation.yml
+++ b/config/authorities/linked_data/DISABLED/scenarios/mesh_bioportal_ld4l_cache_validation.yml
@@ -8,4 +8,4 @@ search:
     result_size: 1800
 term:
   -
-    identifier: 'http://purl.bioontology.org/ontology/MESH/C535700'
+    identifier: 'http://id.nlm.nih.gov/mesh/T736927'


### PR DESCRIPTION
* wikidata - include label in extended context (same as what linked data module does by convention through configurations)
* discogs - action in authority list was set to search when it was fetching a term
* bioportal - was validating with an nih URI instead of a bioportal URI