### PR TITLE
fix failing test for LCNAF RWO title subauth

### DIFF
--- a/config/authorities/linked_data/scenarios/locnames_rwo_ld4l_cache_validation.yml
+++ b/config/authorities/linked_data/scenarios/locnames_rwo_ld4l_cache_validation.yml
@@ -21,7 +21,7 @@ search:
     query: ALA
     subauth: conference
   -
-    query: 'golden notebook'
+    query: 'twain'
     subauth: title
   -
     query: 'Twain, Mark, 1835-1910'


### PR DESCRIPTION
There is no data returned for ‘golden notebook’, but there is for ‘twain’.