### PR TITLE
Add startrecord to LCNAF RWO and authority focused configs

### DIFF
--- a/config/authorities/linked_data/locnames_ld4l_cache.json
+++ b/config/authorities/linked_data/locnames_ld4l_cache.json
@@ -36,7 +36,7 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type": "IriTemplate",
-      "template": "http://services.ld4l.org/ld4l_services/loc_name_batch.jsp?{?query}&{?maxRecords}&{?entity}&{?lang}",
+      "template": "http://services.ld4l.org/ld4l_services/loc_name_batch.jsp?{?query}&{?maxRecords}&{?startRecord}&{?entity}&{?lang}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
@@ -59,6 +59,13 @@
           "property": "hydra:freetextQuery",
           "required": false,
           "default": "20"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "startRecord",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "1"
         },
         {
           "@type": "IriTemplateMapping",

--- a/config/authorities/linked_data/locnames_rwo_ld4l_cache.json
+++ b/config/authorities/linked_data/locnames_rwo_ld4l_cache.json
@@ -36,7 +36,7 @@
     "url": {
       "@context": "http://www.w3.org/ns/hydra/context.jsonld",
       "@type": "IriTemplate",
-      "template": "http://services.ld4l.org/ld4l_services/loc_rwo_name_batch.jsp?{?query}&{?maxRecords}&{?entity}&{?lang}",
+      "template": "http://services.ld4l.org/ld4l_services/loc_rwo_name_batch.jsp?{?query}&{?maxRecords}&{?startRecord}&{?entity}&{?lang}",
       "variableRepresentation": "BasicRepresentation",
       "mapping": [
         {
@@ -59,6 +59,13 @@
           "property": "hydra:freetextQuery",
           "required": false,
           "default": "20"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "startRecord",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "1"
         },
         {
           "@type": "IriTemplateMapping",
@@ -143,7 +150,7 @@
         {
           "property_label_default": "Affiliation",
           "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.field_of_activity",
-          "ldpath": "(madsrdf:hasAffiliation/madsrdf:organization/skos:prefLabel) | (madsrdf:hasAffiliation/madsrdf:organization/rdfs:label) :: xsd:string",
+          "ldpath": "(madsrdf:hasAffiliation/madsrdf:organization/skos:prefLabel) | (madsrdf:hasAffiliation/madsrdf:organization/rdfs:label) | (madsrdf:hasAffiliation/madsrdf:organization/madsrdf:authoritativeLabel) :: xsd:string",
           "selectable": false,
           "drillable": false,
           "subauth": ["person", "organization"]


### PR DESCRIPTION
Adds `(madsrdf:hasAffiliation/madsrdf:organization/madsrdf:authoritativeLabel)` to the Affiliation ldpath for LCNAF RWO.