### PR TITLE
release 4.0.3 to include response header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 4.0.3 (2019-11-22)
+
+* update to LD4P/qa_server 5.0.0
+  * prepends for search query updated to retain response_header in results
+
 ### 4.0.2 (2019-11-22)
 
 * update to samvera/qa 5.1.1

--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,8 @@ gem 'dotenv-deployment'
 gem 'dotenv-rails'
 
 # Required gems for QA and linked data access
-gem 'qa_server', '~> 4.0'
-gem 'qa', '~> 5.0'
+gem 'qa_server', '~> 5.0'
+gem 'qa', '~> 5.1'
 gem 'linkeddata'
 
 # Other gems

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,7 +202,7 @@ GEM
       nokogiri (~> 1.6)
       rails (~> 5.0)
       rdf
-    qa_server (4.0.0)
+    qa_server (5.0.0)
       gruff
       rails (~> 5.0)
     rack (2.0.7)
@@ -428,8 +428,8 @@ DEPENDENCIES
   lograge
   mysql2
   puma (~> 3.7)
-  qa (~> 5.0)
-  qa_server (~> 4.0)
+  qa (~> 5.1)
+  qa_server (~> 5.0)
   rails (~> 5.1.6)
   rails-controller-testing
   rspec-activemodel-mocks

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   qa_server:
-    application_version: "4.0.2"
+    application_version: "4.0.3"
     application_name:  "LD4P Authority Lookup Service"
     footer:
       copyright_html:  "<strong>Copyright &copy; 2018, 2019 Cornell</strong> Licensed under the Apache License, Version 2.0"


### PR DESCRIPTION
4.0.2 was supposed to do this, but the prepend for LD4P/qa_server did not pass through the response header.  Release 5.0.0 of LD4P/qa_server, part of this release, does retain the response header in the results.l