### PR TITLE
Release/4.7.0 - update to qa 5.3 and qa_server 5.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+### 4.7.0 (2019-12-16)
+
+* update to LD4P/qa_server 5.2.1
+  * set monitoring to expire nightly at 3am ET by default
+  * save performance data once a day when running monitoring tests
+* update to Samvera/QA 5.3.0
+  * add a request id to the search and find request headers
+  * log exception for graph load failures
+  * optionally include IP info at start of search/find linked data requests
+
 ### 4.6.0 (2019-12-10)
 
 * update to LD4P/qa_server 5.1.0

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'coffee-rails', '~> 4.2'
 gem 'jbuilder', '~> 2.5'
 gem 'lograge'
 gem 'mysql2'
-gem 'puma', '~> 3.7'
+gem 'puma', '~> 4.3'
 gem 'sass-rails', '~> 5.0'
 gem 'turbolinks', '~> 5'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby] # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,7 +194,8 @@ GEM
     parslet (1.8.2)
     powerpack (0.1.2)
     public_suffix (4.0.1)
-    puma (3.12.2)
+    puma (4.3.1)
+      nio4r (~> 2.0)
     qa (5.3.0)
       activerecord-import
       deprecation
@@ -430,7 +431,7 @@ DEPENDENCIES
   listen
   lograge
   mysql2
-  puma (~> 3.7)
+  puma (~> 4.3)
   qa (~> 5.1)
   qa_server (~> 5.1)
   rails (~> 5.1.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,7 @@ GEM
     bixby (1.0.0)
       rubocop (~> 0.50, <= 0.52.1)
       rubocop-rspec (~> 1.22, <= 1.22.2)
-    builder (3.2.3)
+    builder (3.2.4)
     byebug (11.0.1)
     coderay (1.1.2)
     coffee-rails (4.2.2)
@@ -102,7 +102,8 @@ GEM
       i18n (>= 1.6, < 1.8)
     faraday (0.17.1)
       multipart-post (>= 1.2, < 3)
-    ffi (1.11.1)
+    ffi (1.11.3)
+    geocoder (1.5.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     gruff (0.7.0)
@@ -194,17 +195,19 @@ GEM
     powerpack (0.1.2)
     public_suffix (4.0.1)
     puma (3.12.2)
-    qa (5.2.0)
+    qa (5.3.0)
       activerecord-import
       deprecation
       faraday
+      geocoder
       ldpath
       nokogiri (~> 1.6)
       rails (>= 5.0, < 6.1)
       rdf
-    qa_server (5.1.0)
+    qa_server (5.2.1)
       gruff
       rails (~> 5.0)
+      sass-rails (~> 5.0)
     rack (2.0.7)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -383,7 +386,7 @@ GEM
     temple (0.8.2)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
-    thor (0.20.3)
+    thor (1.0.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
     tins (1.21.1)

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   qa_server:
-    application_version: "4.6.0"
+    application_version: "4.7.0"
     application_name:  "LD4P Authority Lookup Service"
     footer:
       copyright_html:  "<strong>Copyright &copy; 2018, 2019 Cornell</strong> Licensed under the Apache License, Version 2.0"


### PR DESCRIPTION
* update to LD4P/qa_server 5.2.1
  * set monitoring to expire nightly at 3am ET by default
  * save performance data once a day when running monitoring tests
* update to Samvera/QA 5.3.0
  * add a request id to the search and find request headers
  * log exception for graph load failures
  * optionally include IP info at start of search/find linked data requests
* update Puma to 4.3.1