### PR TITLE
do not suppress performance testing & prep for release 4.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 4.7.1 (2019-12-17)
+
+* update config initializers to no longer suppress performance data
+* truncate error messages written to the database instead of raising an exception
+
 ### 4.7.0 (2019-12-16)
 
 * update to LD4P/qa_server 5.2.1

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,6 +4,7 @@ default: &default
   pool: 5
   timeout: 5000
   socket: /var/lib/mysql/mysql.sock
+  strict: false
 
 development:
   <<: *default

--- a/config/initializers/qa.rb
+++ b/config/initializers/qa.rb
@@ -23,4 +23,9 @@ Qa.config do |config|
   # When false, properties that do not override default optional behavior will be shown whether or not the property has a value in the graph.
   # When true, properties that do not override default optional behavior will not be shown whn the property does not have a value in the graph.
   config.property_map_default_for_optional = true
+
+  # IP data including IP address, city, state, and country will be logged with each request.
+  # When false, IP data is logged
+  # When true, IP data will not be logged (default for backward compatibility)
+  config.suppress_ip_data_from_log = false
 end

--- a/config/initializers/qa_server.rb
+++ b/config/initializers/qa_server.rb
@@ -22,5 +22,18 @@ QaServer.config do |config|
     { label: 'API Documentation', url: '/qa/apidoc/' }
   ]
 
-  config.suppress_performance_gathering = true
+  config.suppress_performance_gathering = false
+
+  # Preferred time zone for reporting historical data and performance data
+  # @param [String] time zone name
+  # @see https://api.rubyonrails.org/classes/ActiveSupport/TimeZone.html for possible values of TimeZone names
+  # config.preferred_time_zone_name = 'Eastern Time (US & Canada)'
+
+  # Preferred hour to run monitoring tests
+  # @param [Integer] count of hours from midnight (0-23 with 0=midnight)
+  # @example
+  #   For preferred_time_zone_name of 'Eastern Time (US & Canada)', use 3 for slow down at midnight PT/3am ET
+  #   For preferred_time_zone_name of 'Pacific Time (US & Canada)', use 0 for slow down at midnight PT/3am ET
+  # config.hour_offset_to_run_monitoring_tests = 3
+
 end

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   qa_server:
-    application_version: "4.7.0"
+    application_version: "4.7.1"
     application_name:  "LD4P Authority Lookup Service"
     footer:
       copyright_html:  "<strong>Copyright &copy; 2018, 2019 Cornell</strong> Licensed under the Apache License, Version 2.0"


### PR DESCRIPTION
qa_server 5.2.1 brings in caching of performance test results, so it is no longer a performance issue itself from all the database writes.

* update config initializers to no longer suppress performance data
* truncate error messages written to the database instead of raising an exception