### PR TITLE
update geonames scenario to fetch URI using https instead of http

### DIFF
--- a/config/authorities/linked_data/scenarios/geonames_direct_validation.yml
+++ b/config/authorities/linked_data/scenarios/geonames_direct_validation.yml
@@ -6,4 +6,4 @@ search:
     query: Ithaca
 term:
   -
-    identifier: 'http://sws.geonames.org/261707/'
+    identifier: 'https://sws.geonames.org/261707/'


### PR DESCRIPTION
geonames switched to use https with their URIs instead of http.  This means that the extraction process that depended on the subject URI matching the requested URI failed to find any metadata matching the ldpaths.

Consideration:

Should QA be able to find data in the graph using either/both http and https versions of the requested URI?