### PR TITLE
prep release 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+### 5.0.0 (2020-02-18)
+
+* add extended context for MeSH authority
+* add Ligatus authority
+* add CERL authority
+* update to LD4P/qa_server 6.2.0
+  * use authentication for refreshing monitor tests
+  * add performance cache logger
+  * exceeding max performance cache size flushing the cache
+  * change historical summary to show number of days instead of number of tests
+
 ### 4.8.0 (2020-02-13)
 
 * update to LD4P/qa_server 6.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'dotenv-deployment'
 gem 'dotenv-rails'
 
 # Required gems for QA and linked data access
-gem 'qa_server', '~> 6.0'
+gem 'qa_server', '~> 6.2'
 gem 'qa', '~> 5.3'
 gem 'linkeddata'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,7 +209,7 @@ GEM
       nokogiri (~> 1.6)
       rails (>= 5.0, < 6.1)
       rdf
-    qa_server (6.0.0)
+    qa_server (6.2.0)
       gruff
       rails (~> 5.0)
       sass-rails (~> 5.0)
@@ -439,7 +439,7 @@ DEPENDENCIES
   mysql2
   puma (~> 4.3)
   qa (~> 5.3)
-  qa_server (~> 6.0)
+  qa_server (~> 6.2)
   rails (~> 5.1.6)
   rails-controller-testing
   rspec-activemodel-mocks

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,6 +14,7 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   if Rails.root.join('tmp/caching-dev.txt').exist?
+    # Run rails dev:cache to toggle caching in a file (used in development).
     config.action_controller.perform_caching = true
 
     config.cache_store = :memory_store

--- a/config/initializers/qa_server.rb
+++ b/config/initializers/qa_server.rb
@@ -36,4 +36,6 @@ QaServer.config do |config|
   #   For preferred_time_zone_name of 'Pacific Time (US & Canada)', use 0 for slow down at midnight PT/3am ET
   # config.hour_offset_to_run_monitoring_tests = 3
 
+  config.enable_monitor_status_logging if ENV['MONITOR_STATUS_LOGGIN_ENABLED']
+  config.enable_performance_cache_logging if ENV['PERFORMANCE_CACHE_LOGGIN_ENABLED']
 end

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   qa_server:
-    application_version: "4.8.0"
+    application_version: "5.0.0"
     application_name:  "LD4P Authority Lookup Service"
     footer:
       copyright_html:  "<strong>Copyright &copy; 2018-2020 Cornell</strong> Licensed under the Apache License, Version 2.0"

--- a/db/migrate/20200218125146_add_date_column_to_scenario_run_history.qa_server.rb
+++ b/db/migrate/20200218125146_add_date_column_to_scenario_run_history.qa_server.rb
@@ -1,0 +1,14 @@
+class AddDateColumnToScenarioRunHistory < ActiveRecord::Migration[5.1]
+  def change
+    add_column :scenario_run_history, :date, :date
+    add_index :scenario_run_history, :date
+
+    begin
+      QaServer::ScenarioRunHistory.all.each do |entry|
+        registry = QaServer::ScenarioRunRegistry.find(entry.scenario_run_registry_id)
+        entry.date = registry.dt_stamp.to_date
+        entry.save
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191009174315) do
+ActiveRecord::Schema.define(version: 20200218125146) do
 
   create_table "performance_history", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.datetime "dt_stamp"
@@ -36,7 +36,9 @@ ActiveRecord::Schema.define(version: 20191009174315) do
     t.string "err_message"
     t.integer "scenario_type", default: 0
     t.decimal "run_time", precision: 10, scale: 4
+    t.date "date"
     t.index ["authority_name"], name: "index_scenario_run_history_on_authority_name"
+    t.index ["date"], name: "index_scenario_run_history_on_date"
     t.index ["scenario_run_registry_id"], name: "index_scenario_run_history_on_scenario_run_registry_id"
     t.index ["scenario_type"], name: "index_scenario_run_history_on_scenario_type"
     t.index ["status"], name: "index_scenario_run_history_on_status"


### PR DESCRIPTION
### Change Log

* add extended context for [MeSH](https://id.nlm.nih.gov/mesh/) authority
* add authority [Ligatus](https://www.ligatus.org.uk/lob/)
* add authority [CERL](https://www.cerl.org/)
* update to LD4P/qa_server v6.2.0
  * use authentication for refreshing monitor tests
  * add performance cache logger
  * exceeding max performance cache size flushing the cache
  * change historical summary to show number of days instead of number of tests (original intent)
