### PR TITLE
update qa_server to 7.1.1; attempt display graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ### 5.2.0 (2020-02-20)
 
 * add image processing for AWS
-* update to LD4P/qa_server v7.1.0
+* update to LD4P/qa_server v7.1.1
+  * fix: empty performance cache after running monitor status tests
+* includes changes from LD4P/qa_server v7.1.0  
   * allow performance cache size to be set by environment variable 
   * move generation of history graph to cache_processors
   * log warning in monitor logger if graphs fail to create

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,7 +211,7 @@ GEM
       nokogiri (~> 1.6)
       rails (>= 5.0, < 6.1)
       rdf
-    qa_server (7.1.0)
+    qa_server (7.1.1)
       gruff
       rails (~> 5.0)
       sass-rails (~> 5.0)

--- a/config/initializers/qa_server.rb
+++ b/config/initializers/qa_server.rb
@@ -14,7 +14,7 @@ QaServer.config do |config|
 
   # Displays a graph of historical test data when true
   # @param [Boolean] display history graph when true
-  config.display_historical_graph = false
+  config.display_historical_graph = true
 
   # Displays a datatable of historical test data when true
   # @param [Boolean] display history datatable when true

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   qa_server:
-    application_version: "5.2.0.rc5"
+    application_version: "5.2.0.rc6"
     application_name:  "LD4P Authority Lookup Service"
     footer:
       copyright_html:  "<strong>Copyright &copy; 2018-2020 Cornell</strong> Licensed under the Apache License, Version 2.0"


### PR DESCRIPTION
* writes out performance cache at end of monitor tests run
* attempt to display history graph (should gracefully display nothing if it is not able to create the graph)