### PR TITLE
release 5.2.0

### DIFF
--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   qa_server:
-    application_version: "5.2.0.rc7"
+    application_version: "5.2.0"
     application_name:  "LD4P Authority Lookup Service"
     footer:
       copyright_html:  "<strong>Copyright &copy; 2018-2020 Cornell</strong> Licensed under the Apache License, Version 2.0"


### PR DESCRIPTION
* update to LD4P/qa_server v7.1.1
  * fix: empty performance cache after running monitor status tests
* includes changes from LD4P/qa_server v7.1.0
  * allow performance cache size to be set by environment variable
  * move generation of history graph to cache_processors
  * log warning in monitor logger if graphs fail to create
  * monitor_status page won't try to display graphs if graph file does not exist