### PR TITLE
release 5.2.1 - max_performance_cache_size from ENV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 5.2.1 (2020-02-20)
+
+* remove hardcoded max_performance_cache_size so the value is picked up from ENV
+
 ### 5.2.0 (2020-02-20)
 
 * update to LD4P/qa_server v7.1.1

--- a/config/initializers/qa_server.rb
+++ b/config/initializers/qa_server.rb
@@ -85,7 +85,7 @@ QaServer.config do |config|
 
   # Maximum amount of memory the performance cache can occupy before it is written to the database.
   # @param [Integer] maximum size of performance cache before flushing
-  config.max_performance_cache_size = 500
+  # config.max_performance_cache_size = 32GB
 
   # Enable/Disable logging of performance cache
   # Uncomment one of the lines below to enable or disable performance cache logging.  NOTE: By default, loggers follow the

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   qa_server:
-    application_version: "5.2.0"
+    application_version: "5.2.1"
     application_name:  "LD4P Authority Lookup Service"
     footer:
       copyright_html:  "<strong>Copyright &copy; 2018-2020 Cornell</strong> Licensed under the Apache License, Version 2.0"


### PR DESCRIPTION
* remove hardcoded max_performance_cache_size so the value is picked up from ENV
