### PR TITLE
release 5.2.2 - update to qa_server 7.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
-### 5.2.1 (2020-02-20)
+### 5.2.2 (2020-02-21)
+
+* update to LD4P/qa_server v7.1.2
+  * make configs that return true/false end with ?
+  * add tests for configs that weren’t tested
+  * fix bugs in config#convert_size_to_bytes in response to testing
+
+### 5.2.1 (2020-02-21)
 
 * remove hardcoded max_performance_cache_size so the value is picked up from ENV
 
-### 5.2.0 (2020-02-20)
+### 5.2.0 (2020-02-21)
 
 * update to LD4P/qa_server v7.1.1
   * fix: empty performance cache after running monitor status tests

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,7 +211,7 @@ GEM
       nokogiri (~> 1.6)
       rails (>= 5.0, < 6.1)
       rdf
-    qa_server (7.1.1)
+    qa_server (7.1.2)
       gruff
       rails (~> 5.0)
       sass-rails (~> 5.0)
@@ -461,4 +461,4 @@ DEPENDENCIES
   xray-rails
 
 BUNDLED WITH
-   1.17.1
+   2.1.4

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   qa_server:
-    application_version: "5.2.1"
+    application_version: "5.2.2"
     application_name:  "LD4P Authority Lookup Service"
     footer:
       copyright_html:  "<strong>Copyright &copy; 2018-2020 Cornell</strong> Licensed under the Apache License, Version 2.0"


### PR DESCRIPTION
### 5.2.2 (2020-02-21)

* update to LD4P/qa_server v7.1.2
  * make configs that return true/false end with ?
  * add tests for configs that weren’t tested
  * fix bugs in config#convert_size_to_bytes in response to testing

