### PR TITLE
release 5.3.0 - update qa_server to 7.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 5.3.0 (2020-02-22)
+
+* update to LD4P/qa_server v7.2.0
+  * move generated monitor status graphs from assets to public directory
+
 ### 5.2.4 (2020-02-22)
 
 * fix cerl ct prefix to end with /

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'dotenv-deployment'
 gem 'dotenv-rails'
 
 # Required gems for QA and linked data access
-gem 'qa_server', '~> 7.1'
+gem 'qa_server', '~> 7.2'
 gem 'qa', '~> 5.3'
 gem 'linkeddata'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,7 +211,7 @@ GEM
       nokogiri (~> 1.6)
       rails (>= 5.0, < 6.1)
       rdf
-    qa_server (7.1.3)
+    qa_server (7.2.0)
       gruff
       rails (~> 5.0)
       sass-rails (~> 5.0)
@@ -443,7 +443,7 @@ DEPENDENCIES
   mysql2
   puma (~> 4.3)
   qa (~> 5.3)
-  qa_server (~> 7.1)
+  qa_server (~> 7.2)
   rails (~> 5.1.6)
   rails-controller-testing
   rspec-activemodel-mocks

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   qa_server:
-    application_version: "5.2.4"
+    application_version: "5.3.0"
     application_name:  "LD4P Authority Lookup Service"
     footer:
       copyright_html:  "<strong>Copyright &copy; 2018-2020 Cornell</strong> Licensed under the Apache License, Version 2.0"


### PR DESCRIPTION
* update to LD4P/qa_server v7.2.0
  * move generated monitor status graphs from assets to public directory