### PR TITLE
release 5.3.2 - graphs working on AWS

### DIFF
--- a/.ebextensions/upgrade_bundler.config
+++ b/.ebextensions/upgrade_bundler.config
@@ -1,0 +1,3 @@
+commands:
+  update_bundler:
+    command: /opt/rubies/ruby-2.5.5/bin/gem install bundler -v 2.1.4

--- a/.ebextensions/upgrade_bundler.config
+++ b/.ebextensions/upgrade_bundler.config
@@ -1,3 +1,0 @@
-commands:
-  update_bundler:
-    command: /opt/rubies/ruby-2.1.5/bin/gem install bundler -v 2.1.4

--- a/.ebextensions/upgrade_bundler.config
+++ b/.ebextensions/upgrade_bundler.config
@@ -1,0 +1,3 @@
+commands:
+  update_bundler:
+    command: /opt/rubies/ruby-2.1.5/bin/gem install bundler -v 2.1.4

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@ script/log
 /public/documents
 /public/assets
 /public/sitemap.xml.gz
+/public/qa_server/charts/*
+!/public/qa_server/charts/.keep
 
 # ignore renderer file
 # shows the template being rendered in the html source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 5.3.1 (2020-02-22)
+
+* test new location of graphs in public directory by generating the history graph
+
 ### 5.3.0 (2020-02-22)
 
 * update to LD4P/qa_server v7.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 5.2.4 (2020-02-22)
+
+* update to LD4P/qa_server v7.1.3
+  * bug fix for performance datatable never displays
+
 ### 5.2.3 (2020-02-22)
 
 * update bundler to 2.1.4 on AWS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * generate the performance graphs
 * setup background jobs in all environments
+* update to LD4P/qa_server v7.2.1
+  * fix graph fails generation when any label is empty string
 
 ### 5.3.1 (2020-02-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 5.2.3 (2020-02-22)
+
+* update bundler to 2.1.4 on AWS
+
 ### 5.2.2 (2020-02-21)
 
 * update to LD4P/qa_server v7.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 5.2.4 (2020-02-22)
 
+* fix cerl ct prefix to end with /
 * update to LD4P/qa_server v7.1.3
   * bug fix for performance datatable never displays
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 5.3.2 (2020-02-22)
+
+* generate the performance graphs
+
 ### 5.3.1 (2020-02-22)
 
 * test new location of graphs in public directory by generating the history graph

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 5.3.0 (2020-02-22)
+
+* update to LD4P/qa_server v7.2.0
+  * move generated monitor status graphs from assets to public directory
+
 ### 5.2.4 (2020-02-22)
 
 * fix cerl ct prefix to end with /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 5.3.2 (2020-02-22)
 
 * generate the performance graphs
+* setup background jobs in all environments
 
 ### 5.3.1 (2020-02-22)
 

--- a/Gemfile
+++ b/Gemfile
@@ -38,12 +38,16 @@ group :development, :integration, :test do
   gem 'rubocop-checkstyle_formatter', require: false
 end
 
+gem 'better_errors' # add command line in browser when errors
+gem 'binding_of_caller' # deeper stack trace used by better errors
+gem 'web-console', '~> 3.0' # access to IRB console on exception pages
+
 group :development, :integration do
-  gem 'better_errors' # add command line in browser when errors
-  gem 'binding_of_caller' # deeper stack trace used by better errors
+  # gem 'better_errors' # add command line in browser when errors
+  # gem 'binding_of_caller' # deeper stack trace used by better errors
   gem 'bixby', '~> 1.0.0' # style guide enforcement with rubocop
   gem 'spring' # Spring speeds up development by keeping your application running in the background.
-  gem 'web-console', '~> 3.0' # access to IRB console on exception pages
+  # gem 'web-console', '~> 3.0' # access to IRB console on exception pages
   gem 'xray-rails'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'dotenv-deployment'
 gem 'dotenv-rails'
 
 # Required gems for QA and linked data access
-gem 'qa_server', '~> 7.1'
+gem 'qa_server', '~> 7.2'
 gem 'qa', '~> 5.3'
 gem 'linkeddata'
 

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'linkeddata'
 
 # Other gems
 gem 'coffee-rails', '~> 4.2'
+gem 'concurrent-ruby'
 gem 'jbuilder', '~> 2.5'
 gem 'lograge'
 gem 'mysql2'
@@ -53,6 +54,3 @@ group :test do
 end
 
 gem 'swagger-docs'
-
-# temporary pins to avoid bundler difficulties
-gem 'concurrent-ruby', '1.0.5'

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'turbolinks', '~> 5'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby] # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'uglifier', '>= 1.3.0'
 
-group :development, :integration, :test do
+group :development, :test do
   gem 'byebug'
   gem 'coveralls', require: false
   gem 'database_cleaner'
@@ -34,20 +34,16 @@ group :development, :integration, :test do
   gem 'faker'
   gem 'listen'
   gem 'rails-controller-testing'
-  gem 'rubocop'
-  gem 'rubocop-checkstyle_formatter', require: false
 end
 
-gem 'better_errors' # add command line in browser when errors
-gem 'binding_of_caller' # deeper stack trace used by better errors
-gem 'web-console', '~> 3.0' # access to IRB console on exception pages
-
-group :development, :integration do
-  # gem 'better_errors' # add command line in browser when errors
-  # gem 'binding_of_caller' # deeper stack trace used by better errors
+group :development do
+  gem 'better_errors' # add command line in browser when errors
+  gem 'binding_of_caller' # deeper stack trace used by better errors
   gem 'bixby', '~> 1.0.0' # style guide enforcement with rubocop
+  gem 'rubocop'
+  gem 'rubocop-checkstyle_formatter', require: false
   gem 'spring' # Spring speeds up development by keeping your application running in the background.
-  # gem 'web-console', '~> 3.0' # access to IRB console on exception pages
+  gem 'web-console', '~> 3.0' # access to IRB console on exception pages
   gem 'xray-rails'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.6)
     connection_pool (2.2.2)
     coveralls (0.8.23)
       json (>= 1.8, < 3)
@@ -429,7 +429,7 @@ DEPENDENCIES
   bixby (~> 1.0.0)
   byebug
   coffee-rails (~> 4.2)
-  concurrent-ruby (= 1.0.5)
+  concurrent-ruby
   coveralls
   database_cleaner
   dotenv-deployment
@@ -461,4 +461,4 @@ DEPENDENCIES
   xray-rails
 
 BUNDLED WITH
-   1.17.1
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -461,4 +461,4 @@ DEPENDENCIES
   xray-rails
 
 BUNDLED WITH
-   2.1.4
+   1.17.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,7 +211,7 @@ GEM
       nokogiri (~> 1.6)
       rails (>= 5.0, < 6.1)
       rdf
-    qa_server (7.2.0)
+    qa_server (7.2.1)
       gruff
       rails (~> 5.0)
       sass-rails (~> 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,7 +211,7 @@ GEM
       nokogiri (~> 1.6)
       rails (>= 5.0, < 6.1)
       rdf
-    qa_server (7.1.3)
+    qa_server (7.2.0)
       gruff
       rails (~> 5.0)
       sass-rails (~> 5.0)
@@ -443,7 +443,7 @@ DEPENDENCIES
   mysql2
   puma (~> 4.3)
   qa (~> 5.3)
-  qa_server (~> 7.1)
+  qa_server (~> 7.2)
   rails (~> 5.1.6)
   rails-controller-testing
   rspec-activemodel-mocks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,7 +211,7 @@ GEM
       nokogiri (~> 1.6)
       rails (>= 5.0, < 6.1)
       rdf
-    qa_server (7.1.2)
+    qa_server (7.1.3)
       gruff
       rails (~> 5.0)
       sass-rails (~> 5.0)

--- a/config/authorities/linked_data/cerl_ld4l_cache.json
+++ b/config/authorities/linked_data/cerl_ld4l_cache.json
@@ -4,8 +4,8 @@
   "prefixes": {
     "rdaGr2": "http://rdvocab.info/ElementsGr2/",
     "rdaGr3": "http://rdvocab.info/ElementsGr3/",
-    "ct": "http://www.cerl.org/namespaces/thesaurus",
-    "rdaRelGr2": "http://metadataregistry.org/uri/schema/RDARelationshipsGR2",
+    "ct": "http://www.cerl.org/namespaces/thesaurus/",
+    "rdaRelGr2": "http://metadataregistry.org/uri/schema/RDARelationshipsGR2/",
     "vivo": "http://vivoweb.org/ontology/core#"
   },
   "term": {

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,13 +13,13 @@ Rails.application.configure do
   config.consider_all_requests_local = true
 
   # Enable/disable caching. By default caching is disabled.
-  if Rails.root.join('tmp/caching-dev.txt').exist?
+  if Rails.root.join('tmp', 'caching-dev.txt').exist?
     # Run rails dev:cache to toggle caching in a file (used in development).
     config.action_controller.perform_caching = true
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      'Cache-Control' => 'public, max-age=172800'
+      'Cache-Control' => "public, max-age=#{2.days.to_i}"
     }
   else
     config.action_controller.perform_caching = false
@@ -59,4 +59,7 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.active_job.queue_adapter = :async # runs in-memory; a crash will lose the job; change to :inline to run immediately for debugging
+  # config.active_job.queue_adapter = :inline # runs when it is called for debugging
 end

--- a/config/environments/integration.rb
+++ b/config/environments/integration.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
   config.log_level = :info
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -61,6 +61,10 @@ Rails.application.configure do
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "qa_server_#{Rails.env}"
+
+  # run jobs asynchronously in background (ok because only background jobs are related to monitoring status)
+  config.active_job.queue_adapter = :async # runs in-memory; a crash will lose the job; change to :inline to run immediately for debugging
+
   config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,6 +55,10 @@ Rails.application.configure do
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "qa_server_#{Rails.env}"
+
+  # run jobs asynchronously in background (ok because only background jobs are related to monitoring status)
+  config.active_job.queue_adapter = :async # runs in-memory; a crash will lose the job; change to :inline to run immediately for debugging
+
   config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -61,6 +61,10 @@ Rails.application.configure do
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "qa_server_#{Rails.env}"
+
+  # run jobs asynchronously in background (ok because only background jobs are related to monitoring status)
+  config.active_job.queue_adapter = :async # runs in-memory; a crash will lose the job; change to :inline to run immediately for debugging
+
   config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.

--- a/config/initializers/qa_server.rb
+++ b/config/initializers/qa_server.rb
@@ -26,7 +26,7 @@ QaServer.config do |config|
 
   # Displays a graph of performance test data when true
   # @param [Boolean] display performance graph when true
-  config.display_performance_graph = false
+  config.display_performance_graph = true
 
   # Max time in milliseconds for y-axis in the performance graphs.
   # @param [Integer] milliseconds

--- a/config/initializers/qa_server.rb
+++ b/config/initializers/qa_server.rb
@@ -14,7 +14,7 @@ QaServer.config do |config|
 
   # Displays a graph of historical test data when true
   # @param [Boolean] display history graph when true
-  config.display_historical_graph = false
+  config.display_historical_graph = true
 
   # Displays a datatable of historical test data when true
   # @param [Boolean] display history datatable when true

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   qa_server:
-    application_version: "5.3.2"
+    application_version: "5.3.2.rc1"
     application_name:  "LD4P Authority Lookup Service"
     footer:
       copyright_html:  "<strong>Copyright &copy; 2018-2020 Cornell</strong> Licensed under the Apache License, Version 2.0"

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   qa_server:
-    application_version: "5.2.3"
+    application_version: "5.2.4"
     application_name:  "LD4P Authority Lookup Service"
     footer:
       copyright_html:  "<strong>Copyright &copy; 2018-2020 Cornell</strong> Licensed under the Apache License, Version 2.0"

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   qa_server:
-    application_version: "5.3.0"
+    application_version: "5.3.1"
     application_name:  "LD4P Authority Lookup Service"
     footer:
       copyright_html:  "<strong>Copyright &copy; 2018-2020 Cornell</strong> Licensed under the Apache License, Version 2.0"

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   qa_server:
-    application_version: "5.3.1"
+    application_version: "5.3.2"
     application_name:  "LD4P Authority Lookup Service"
     footer:
       copyright_html:  "<strong>Copyright &copy; 2018-2020 Cornell</strong> Licensed under the Apache License, Version 2.0"

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   qa_server:
-    application_version: "5.3.2.rc3"
+    application_version: "5.3.2.rc4"
     application_name:  "LD4P Authority Lookup Service"
     footer:
       copyright_html:  "<strong>Copyright &copy; 2018-2020 Cornell</strong> Licensed under the Apache License, Version 2.0"

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   qa_server:
-    application_version: "5.2.3"
+    application_version: "5.2.3.rc1"
     application_name:  "LD4P Authority Lookup Service"
     footer:
       copyright_html:  "<strong>Copyright &copy; 2018-2020 Cornell</strong> Licensed under the Apache License, Version 2.0"

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   qa_server:
-    application_version: "5.2.3.rc2"
+    application_version: "5.2.3"
     application_name:  "LD4P Authority Lookup Service"
     footer:
       copyright_html:  "<strong>Copyright &copy; 2018-2020 Cornell</strong> Licensed under the Apache License, Version 2.0"

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   qa_server:
-    application_version: "5.3.2.rc2"
+    application_version: "5.3.2.rc3"
     application_name:  "LD4P Authority Lookup Service"
     footer:
       copyright_html:  "<strong>Copyright &copy; 2018-2020 Cornell</strong> Licensed under the Apache License, Version 2.0"

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   qa_server:
-    application_version: "5.2.2"
+    application_version: "5.2.3"
     application_name:  "LD4P Authority Lookup Service"
     footer:
       copyright_html:  "<strong>Copyright &copy; 2018-2020 Cornell</strong> Licensed under the Apache License, Version 2.0"

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   qa_server:
-    application_version: "5.3.2.rc4"
+    application_version: "5.3.2"
     application_name:  "LD4P Authority Lookup Service"
     footer:
       copyright_html:  "<strong>Copyright &copy; 2018-2020 Cornell</strong> Licensed under the Apache License, Version 2.0"

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   qa_server:
-    application_version: "5.2.3.rc1"
+    application_version: "5.2.3.rc2"
     application_name:  "LD4P Authority Lookup Service"
     footer:
       copyright_html:  "<strong>Copyright &copy; 2018-2020 Cornell</strong> Licensed under the Apache License, Version 2.0"

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   qa_server:
-    application_version: "5.3.2.rc1"
+    application_version: "5.3.2.rc2"
     application_name:  "LD4P Authority Lookup Service"
     footer:
       copyright_html:  "<strong>Copyright &copy; 2018-2020 Cornell</strong> Licensed under the Apache License, Version 2.0"

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   qa_server:
-    application_version: "5.2.4"
+    application_version: "5.3.0"
     application_name:  "LD4P Authority Lookup Service"
     footer:
       copyright_html:  "<strong>Copyright &copy; 2018-2020 Cornell</strong> Licensed under the Apache License, Version 2.0"


### PR DESCRIPTION
### 5.3.2 (2020-02-22)

* generate the performance graphs
* setup background jobs in all environments
* update to LD4P/qa_server v7.2.1
  * fix graph fails generation when any label is empty string

### 5.3.1 (2020-02-22)

* test new location of graphs in public directory by generating the history graph

### 5.3.0 (2020-02-22)

* update to LD4P/qa_server v7.2.0
  * move generated monitor status graphs from assets to public directory

