### PR TITLE
add meeting subauth to oclcfast_direct

### DIFF
--- a/config/authorities/linked_data/oclcfast_direct.json
+++ b/config/authorities/linked_data/oclcfast_direct.json
@@ -73,6 +73,7 @@
       "geocoordinates": "oclc.geographic",
       "geographic":     "oclc.geographic",
       "event_name":     "oclc.eventName",
+      "meeting":        "oclc.meeting",
       "person":         "oclc.personalName",
       "personal_name":  "oclc.personalName",
       "organization":   "oclc.corporateName",


### PR DESCRIPTION
According to OCLC, eventName entity is being split.  A new entity 'meeting' will be added.  They stated that most events are actually meetings.  It is unclear that eventName will continue once this process is complete.  There was a question locally asking the question whether something like WWII would be treated as a meeting instead of an event. 