### PR TITLE
Remove failing tests as they are due to changes at OCLC

### DIFF
--- a/config/authorities/linked_data/scenarios/oclc_fast_validation.yml
+++ b/config/authorities/linked_data/scenarios/oclc_fast_validation.yml
@@ -16,11 +16,16 @@ search:
     subauth: geographic
     replacements:
       maximumRecords: '4'
-  -
-    query: Festival
-    subauth: event_name
-    replacements:
-      maximumRecords: '4'
+#  -
+#    query: War
+#    subauth: event_name
+#    replacements:
+#      maxRecords: '4'
+#  -
+#    query: Festival
+#    subauth: meeting
+#    replacements:
+#      maxRecords: '4'
   -
     query: 'mark twain'
     subauth: personal_name

--- a/config/authorities/linked_data/scenarios/oclcfast_direct_validation.yml
+++ b/config/authorities/linked_data/scenarios/oclcfast_direct_validation.yml
@@ -22,9 +22,14 @@ search:
     subauth: topic
     replacements:
       maxRecords: '4'
+#  -
+#    query: War
+#    subauth: event_name
+#    replacements:
+#      maxRecords: '4'
   -
     query: Festival
-    subauth: event_name
+    subauth: meeting
     replacements:
       maxRecords: '4'
   -


### PR DESCRIPTION
OCLC moved most events to be meetings.  As part of this move, the linked data search results only return `rdf:type Meeting` even if the term has `rdf:type Event Name`.

For now, tests are being disabled.

Issue https://github.com/LD4P/qa_server/issues/327 records the need to revisit this as the linked data at OCLC continues to evolve.