### PR TITLE
Release/5.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * remove failing tests as they are due to changes at OCLC
 * have wikidata always return with response_header and results
 * add ISNI authority
+* turn graphs off for production
 * update to LD4P/qa_server v7.3.0
   * move graph generation to background jobs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 5.4.0 (2020-04-08)
+
+* remove failing tests as they are due to changes at OCLC
+* have wikidata always return with response_header and results
+* add ISNI authority
+* update to LD4P/qa_server v7.3.0
+  * move graph generation to background jobs
+
 ### 5.3.2 (2020-02-22)
 
 * generate the performance graphs

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'dotenv-deployment'
 gem 'dotenv-rails'
 
 # Required gems for QA and linked data access
-gem 'qa_server', '~> 7.2'
+gem 'qa_server', '~> 7.3'
 gem 'qa', '~> 5.3'
 gem 'linkeddata'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,8 +106,8 @@ GEM
     geocoder (1.6.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    gruff (0.7.0)
-      rmagick (~> 2.13, >= 2.13.4)
+    gruff (0.8.0)
+      rmagick
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -175,12 +175,12 @@ GEM
       activesupport (>= 4)
       railties (>= 4)
       request_store (~> 1.0)
-    loofah (2.4.0)
+    loofah (2.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
-    method_source (0.9.2)
+    method_source (1.0.0)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
@@ -190,7 +190,7 @@ GEM
     net-http-persistent (3.1.0)
       connection_pool (~> 2.2)
     nio4r (2.5.2)
-    nokogiri (1.10.8)
+    nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     nokogumbo (2.0.2)
       nokogiri (~> 1.8, >= 1.8.4)
@@ -211,7 +211,7 @@ GEM
       nokogiri (~> 1.6)
       rails (>= 5.0, < 6.1)
       rdf
-    qa_server (7.2.1)
+    qa_server (7.3.0)
       gruff
       rails (~> 5.0)
       sass-rails (~> 5.0)
@@ -308,7 +308,7 @@ GEM
       rdf (~> 3.1)
     request_store (1.5.0)
       rack (>= 1.4)
-    rmagick (2.16.0)
+    rmagick (4.1.1)
     rspec-activemodel-mocks (1.1.0)
       activemodel (>= 3.0)
       activesupport (>= 3.0)
@@ -403,7 +403,7 @@ GEM
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
-    tzinfo (1.2.6)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
@@ -443,7 +443,7 @@ DEPENDENCIES
   mysql2
   puma (~> 4.3)
   qa (~> 5.3)
-  qa_server (~> 7.2)
+  qa_server (~> 7.3)
   rails (~> 5.1.6)
   rails-controller-testing
   rspec-activemodel-mocks

--- a/config/initializers/qa_server.rb
+++ b/config/initializers/qa_server.rb
@@ -14,7 +14,7 @@ QaServer.config do |config|
 
   # Displays a graph of historical test data when true
   # @param [Boolean] display history graph when true
-  config.display_historical_graph = true
+  config.display_historical_graph = false
 
   # Displays a datatable of historical test data when true
   # @param [Boolean] display history datatable when true
@@ -26,7 +26,7 @@ QaServer.config do |config|
 
   # Displays a graph of performance test data when true
   # @param [Boolean] display performance graph when true
-  config.display_performance_graph = true
+  config.display_performance_graph = false
 
   # Displays a datatable of performance test data when true
   # @param [Boolean] display performance datatable when true

--- a/config/initializers/qa_server.rb
+++ b/config/initializers/qa_server.rb
@@ -14,7 +14,7 @@ QaServer.config do |config|
 
   # Displays a graph of historical test data when true
   # @param [Boolean] display history graph when true
-  config.display_historical_graph = false
+  config.display_historical_graph = true
 
   # Displays a datatable of historical test data when true
   # @param [Boolean] display history datatable when true
@@ -26,7 +26,7 @@ QaServer.config do |config|
 
   # Displays a graph of performance test data when true
   # @param [Boolean] display performance graph when true
-  config.display_performance_graph = false
+  config.display_performance_graph = true
 
   # Displays a datatable of performance test data when true
   # @param [Boolean] display performance datatable when true

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   qa_server:
-    application_version: "5.3.2"
+    application_version: "5.4.0.rc1"
     application_name:  "LD4P Authority Lookup Service"
     footer:
       copyright_html:  "<strong>Copyright &copy; 2018-2020 Cornell</strong> Licensed under the Apache License, Version 2.0"

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   qa_server:
-    application_version: "5.4.0.rc1"
+    application_version: "5.4.0"
     application_name:  "LD4P Authority Lookup Service"
     footer:
       copyright_html:  "<strong>Copyright &copy; 2018-2020 Cornell</strong> Licensed under the Apache License, Version 2.0"


### PR DESCRIPTION
* remove failing tests as they are due to changes at OCLC
* have wikidata always return with response_header and results
* add ISNI authority
* turn graphs off for production
* update to LD4P/qa_server v7.3.0
  * move graph generation to background jobs