### PR TITLE
add loc small vocabularies

### DIFF
--- a/config/authorities/linked_data/locvocabs_ld4l_cache.json
+++ b/config/authorities/linked_data/locvocabs_ld4l_cache.json
@@ -7,31 +7,6 @@
     "vivo":    "http://vivoweb.org/ontology/core#"
   },
   "term": {
-    "url": {
-      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
-      "@type":    "IriTemplate",
-      "template": "http://services.ld4l.org/ld4l_services/loc_vocab_lookup.jsp?uri={term_uri}",
-      "variableRepresentation": "BasicRepresentation",
-      "mapping": [
-        {
-          "@type":    "IriTemplateMapping",
-          "variable": "term_uri",
-          "property": "hydra:freetextQuery",
-          "required": true,
-          "encode":   true
-        }
-      ]
-    },
-    "qa_replacement_patterns": {
-      "term_id": "term_uri"
-    },
-    "term_id": "URI",
-    "results": {
-      "id_ldpath":       "loc:lccn ::xsd:string",
-      "label_ldpath":    "skos:prefLabel ::xsd:string",
-      "altlabel_ldpath": "madsrdf:hasVariant/madsrdf:variantLabel ::xsd:string",
-      "sameas_ldpath":   "skos:exactMatch ::xsd:anyURI"
-    }
   },
   "search": {
     "url": {

--- a/config/authorities/linked_data/locvocabs_ld4l_cache.json
+++ b/config/authorities/linked_data/locvocabs_ld4l_cache.json
@@ -1,0 +1,142 @@
+{
+  "QA_CONFIG_VERSION": "2.2",
+  "service_uri": "http://ld4l.org/ld4l_services/cache",
+  "prefixes": {
+    "loc":     "http://id.loc.gov/vocabulary/identifiers/",
+    "madsrdf": "http://www.loc.gov/mads/rdf/v1#",
+    "vivo":    "http://vivoweb.org/ontology/core#"
+  },
+  "term": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type":    "IriTemplate",
+      "template": "http://services.ld4l.org/ld4l_services/loc_vocab_lookup.jsp?uri={term_uri}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type":    "IriTemplateMapping",
+          "variable": "term_uri",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode":   true
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "term_id": "term_uri"
+    },
+    "term_id": "URI",
+    "results": {
+      "id_ldpath":       "loc:lccn ::xsd:string",
+      "label_ldpath":    "skos:prefLabel ::xsd:string",
+      "altlabel_ldpath": "madsrdf:hasVariant/madsrdf:variantLabel ::xsd:string",
+      "sameas_ldpath":   "skos:exactMatch ::xsd:anyURI"
+    }
+  },
+  "search": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type": "IriTemplate",
+      "template": "http://services.ld4l.org/ld4l_services/loc_vocab_batch.jsp?{?query}&{?entity}&{?maxRecords}&{?startRecord}&{?lang}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "query",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode": true
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "entity",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": ""
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "maxRecords",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "20"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "startRecord",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "1"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "lang",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "en"
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "query":   "query",
+      "subauth": "entity",
+      "start_record": "startRecord",
+      "requested_records": "maxRecords"
+    },
+    "total_count_ldpath": "vivo:count",
+    "results": {
+      "label_ldpath":    "skos:prefLabel ::xsd:string",
+      "sort_ldpath":     "vivo:rank ::xsd:string"
+    },
+    "subauthorities": {
+      "carriers":            "carriers",
+      "content_types":       "contentTypes",
+      "description_conventions": "descriptionConventions",
+      "frequencies":         "frequencies",
+      "issuance":            "issuance",
+      "marcauthen":          "marcauthen",
+      "maspect":             "maspect",
+      "maudience":           "maudience",
+      "mbroadstd":           "mbroadstd",
+      "mcapturestorage":     "mcapturestorage",
+      "mcolor":              "mcolor",
+      "media_types":         "mediaTypes",
+      "mencformat":          "mencformat",
+      "menclvl":             "menclvl",
+      "mfiletype":           "mfiletype",
+      "mfont":               "mfont",
+      "mgeneration":         "mgeneration",
+      "mgovtpubtype":        "mgovtpubtype",
+      "mgroove":             "mgroove",
+      "millus":              "millus",
+      "mlayout":             "mlayout",
+      "mmaterial":           "mmaterial",
+      "mmusicformat":        "mmusicformat",
+      "mmusnotation":        "mmusnotation",
+      "mplayback":           "mplayback",
+      "mplayspeed":          "mplayspeed",
+      "mpolarity":           "mpolarity",
+      "mpresformat":         "mpresformat",
+      "mproduction":         "mproduction",
+      "mprojection":         "mprojection",
+      "mpunctuation_conventions": "mpunctuationConventions",
+      "mrecmedium":          "mrecmedium",
+      "mrectype":            "mrectype",
+      "mreductionratio":     "mreductionratio",
+      "mregencoding":        "mregencoding",
+      "mrelief":             "mrelief",
+      "mscale":              "mscale",
+      "mscript":             "mscript",
+      "msoundcontent":       "msoundcontent",
+      "mspecplayback":       "mspecplayback",
+      "mstatus":             "mstatus",
+      "msupplcont":          "msupplcont",
+      "mtactile":            "mtactile",
+      "mtapeconfig":         "mtapeconfig",
+      "mtechnique":          "mtechnique",
+      "mvidformat":          "mvidformat",
+      "relators":            "relators",
+      "resource_components": "resourceComponents"
+    }
+  }
+}

--- a/config/authorities/linked_data/scenarios/locvocabs_ld4l_cache_validation.yml
+++ b/config/authorities/linked_data/scenarios/locvocabs_ld4l_cache_validation.yml
@@ -1,0 +1,188 @@
+# Supported subauthorities:
+#   carriers
+#   content_types
+---
+authority:
+  service: ld4l_cache
+  context: false
+search:
+  -
+    query: audio
+    subauth: carriers
+  -
+    query: image
+    subauth: content_types
+  -
+    query: rare books
+    subauth: description_conventions
+  -
+    query: daily
+    subauth: frequencies
+    result_size: 120
+  -
+    query: serial
+    subauth: issuance
+    result_size: 110
+  -
+    query: ISSN
+    subauth: marcauthen
+  -
+    query: full
+    subauth: maspect
+    result_size: 110
+  -
+    query: general
+    subauth: maudience
+    result_size: 110
+  -
+    query: pal
+    subauth: mbroadstd
+    result_size: 110
+  -
+    query: electrical
+    subauth: mcapturestorage
+  -
+    query: gray
+    subauth: mcolor
+    result_size: 110
+  -
+    query: video
+    subauth: media_types
+    result_size: 110
+  -
+    query: dvd
+    subauth: mencformat
+  -
+    query: core
+    subauth: menclvl
+    result_size: 100
+  -
+    query: data
+    subauth: mfiletype
+    result_size: 110
+  -
+    query: print
+    subauth: mfont
+  -
+    query: original
+    subauth: mgeneration
+  -
+    query: state
+    subauth: mgovtpubtype
+    result_size: 110
+  -
+    query: fine
+    subauth: mgroove
+    result_size: 110
+  -
+    query: music
+    subauth: millus
+    result_size: 110
+  -
+    query: paragraph
+    subauth: mlayout
+    result_size: 110
+  -
+    query: vinyl
+    subauth: mmaterial
+    result_size: 110
+  -
+    query: score
+    subauth: mmusicformat
+  -
+    query: tablature
+    subauth: mmusnotation
+    result_size: 100
+  -
+    query: mixed
+    subauth: mplayback
+    result_size: 100
+  -
+    query: 160
+    subauth: mplayspeed
+    result_size: 100
+  -
+    query: negative
+    subauth: mpolarity
+    result_size: 100
+  -
+    query: multiscreen
+    subauth: mpresformat
+    result_size: 100
+  -
+    query: etching
+    subauth: mproduction
+    result_size: 100
+  -
+    query: miller
+    subauth: mprojection
+  -
+    query: isbd
+    subauth: mpunctuation_conventions
+    result_size: 100
+  -
+    query: optical
+    subauth: mrecmedium
+    result_size: 100
+  -
+    query: analog
+    subauth: mrectype
+    result_size: 100
+  -
+    query: high
+    subauth: mreductionratio
+  -
+    query: region 8
+    subauth: mregencoding
+    result_size: 100
+  -
+    query: land
+    subauth: mrelief
+    result_size: 100
+  -
+    query: scale
+    subauth: mscale
+    result_size: 100
+  -
+    query: chinese
+    subauth: mscript
+    result_size: 100
+  -
+    query: silent
+    subauth: msoundcontent
+    result_size: 100
+  -
+    query: audio
+    subauth: mspecplayback
+  -
+    query: invalid
+    subauth: mstatus
+    result_size: 100
+  -
+    query: index
+    subauth: msupplcont
+  -
+    query: braille
+    subauth: mtactile
+  -
+    query: half
+    subauth: mtapeconfig
+    result_size: 100
+  -
+    query: action
+    subauth: mtechnique
+  -
+    query: laser
+    subauth: mvidformat
+    result_size: 100
+  -
+    query: actor
+    subauth: relators
+  -
+    query: sound
+    subauth: resource_components
+    result_size: 100
+
+term:
+  -
+    identifier: 'http://id.loc.gov/vocabulary/contentTypes/sti'

--- a/config/authorities/linked_data/scenarios/locvocabs_ld4l_cache_validation.yml
+++ b/config/authorities/linked_data/scenarios/locvocabs_ld4l_cache_validation.yml
@@ -183,6 +183,6 @@ search:
     subauth: resource_components
     result_size: 100
 
-term:
-  -
-    identifier: 'http://id.loc.gov/vocabulary/contentTypes/sti'
+#term:
+#  -
+#    identifier: 'http://id.loc.gov/vocabulary/contentTypes/sti'


### PR DESCRIPTION
At least temporarily, removing access to fetch terms for locvocab in the second commit.

Working to determine if support for term fetch is a requirement.  It is not currently supported by the cache for the LOC small vocabularies.