### PR TITLE
update and sync authority definitions: loc, getty, and a few others

### DIFF
--- a/config/authorities/linked_data/getty_aat_ld4l_cache.json
+++ b/config/authorities/linked_data/getty_aat_ld4l_cache.json
@@ -2,6 +2,7 @@
   "QA_CONFIG_VERSION": "2.2",
   "service_uri": "http://ld4l.org/ld4l_services/cache",
   "prefixes": {
+    "getty":   "http://vocab.getty.edu/ontology#",
     "vivo":    "http://vivoweb.org/ontology/core#"
   },
   "term": {
@@ -89,6 +90,67 @@
       "label_ldpath": "skos:prefLabel ::xsd:string",
       "sort_ldpath":  "vivo:rank ::xsd:string"
     },
+    "context": {
+      "groups": {
+        "hierarchies": {
+          "group_label_i18n": "qa.linked_data.authority.getty_aat_ld4l_cache.hierarchies",
+          "group_label_default": "Hierarchies"
+        }
+      },
+      "properties": [
+        {
+          "property_label_i18n": "qa.linked_data.authority.getty_aat_ld4l_cache.preferred_label",
+          "property_label_default": "Preferred label",
+          "ldpath": "skos:prefLabel :: xsd:string",
+          "selectable": true,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.getty_aat_ld4l_cache.alt_label",
+          "property_label_default": "Alternative Label",
+          "ldpath": "skos:altLabel :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "group_id": "hierarchies",
+          "property_label_i18n": "qa.linked_data.authority.getty_aat_ld4l_cache.broader",
+          "property_label_default": "Broader",
+          "ldpath": "skos:broader :: xsd:string",
+          "selectable": true,
+          "drillable": true,
+          "expansion_label_ldpath": "skos:prefLabel ::xsd:string",
+          "expansion_id_ldpath": "dc:identifier ::xsd:string"
+        },
+        {
+          "group_id": "hierarchies",
+          "property_label_i18n": "qa.linked_data.authority.getty_aat_ld4l_cache.narrower",
+          "property_label_default": "Narrower",
+          "ldpath": "skos:narrower :: xsd:string",
+          "selectable": true,
+          "drillable": true,
+          "expansion_label_ldpath": "skos:prefLabel ::xsd:string",
+          "expansion_id_ldpath": "dc:identifier ::xsd:string"
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.getty_aat_ld4l_cache.scope_note",
+          "property_label_default": "Scope note",
+          "ldpath": "skos:scopeNote :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "group_id": "hierarchies",
+          "property_label_i18n": "qa.linked_data.authority.getty_aat_ld4l_cache.hierarchy",
+          "property_label_default": "Hierarchy",
+          "ldpath": "gvp:broaderPreferredExtended :: xsd:string",
+          "selectable": true,
+          "drillable": true,
+          "expansion_label_ldpath": "skos:prefLabel ::xsd:string",
+          "expansion_id_ldpath": "dc:identifier ::xsd:string"
+        }
+      ]
+    },
     "subauthorities": {
       "Activities":                              "&facet=300264090",
       "Activities__Disciplines":                  "&facet=300054134",
@@ -123,4 +185,3 @@
     }
   }
 }
-

--- a/config/authorities/linked_data/getty_tgn_ld4l_cache.json
+++ b/config/authorities/linked_data/getty_tgn_ld4l_cache.json
@@ -3,7 +3,8 @@
   "service_uri": "http://ld4l.org/ld4l_services/cache",
   "prefixes": {
     "getty":   "http://vocab.getty.edu/ontology#",
-    "vivo":    "http://vivoweb.org/ontology/core#"
+    "vivo":    "http://vivoweb.org/ontology/core#",
+    "xl":      "http://www.w3.org/2008/05/skos-xl#"
   },
   "term": {
     "url": {
@@ -85,11 +86,34 @@
     "context": {
       "properties": [
         {
-          "property_label_i18n": "qa.linked_data.authority.getty_tgn_ld4l_cache.parent_string",
-          "property_label_default": "Parent",
-          "ldpath": "getty:parentString :: xsd:string",
+          "property_label_i18n": "qa.linked_data.authority.getty_tgn_ld4l_cache.preferred_label",
+          "property_label_default": "Preferred label",
+          "ldpath": "^foaf:focus/xl:prefLabel/xl:literalForm :: xsd:string",
+          "selectable": true,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.getty_tgn_ld4l_cache.variant_label",
+          "property_label_default": "Variant Label",
+          "ldpath": "^foaf:focus/xl:altLabel/xl:literalForm :: xsd:string",
           "selectable": false,
           "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.getty_tgn_ld4l_cache.place_type",
+          "property_label_default": "Place type",
+          "ldpath": "^foaf:focus/gvp:placeTypePreferred :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.getty_aat_ld4l_cache.broader",
+          "property_label_default": "Broader",
+          "ldpath": "^foaf:focus/gvp:broaderPreferred/xl:altLabel/xl:literalForm :: xsd:string",
+          "selectable": false,
+          "drillable": true,
+          "expansion_label_ldpath": "skos:prefLabel ::xsd:string",
+          "expansion_id_ldpath": "dc:identifier ::xsd:string"
         }
       ]
     }

--- a/config/authorities/linked_data/locdemographics_new_ld4l_cache.json
+++ b/config/authorities/linked_data/locdemographics_new_ld4l_cache.json
@@ -1,0 +1,184 @@
+{
+  "QA_CONFIG_VERSION": "2.2",
+  "service_uri": "http://ld4l.org/ld4l_services/cache",
+  "prefixes": {
+    "loc":     "http://id.loc.gov/vocabulary/identifiers/",
+    "madsrdf": "http://www.loc.gov/mads/rdf/v1#",
+    "vivo":    "http://vivoweb.org/ontology/core#"
+  },
+  "term": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type":    "IriTemplate",
+      "template": "http://wintermute.slis.uiowa.edu:8081/ld4l_services/loc_demographics_lookup.jsp?uri={term_uri}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type":    "IriTemplateMapping",
+          "variable": "term_uri",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode":   true
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "term_id": "term_uri"
+    },
+    "term_id": "URI",
+    "results": {
+      "id_ldpath":       "loc:lccn ::xsd:string",
+      "label_ldpath":    "skos:prefLabel ::xsd:string",
+      "altlabel_ldpath": "madsrdf:hasVariant/madsrdf:variantLabel ::xsd:string",
+      "sameas_ldpath":   "skos:exactMatch ::xsd:anyURI"
+    }
+  },
+  "search": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type": "IriTemplate",
+      "template": "http://wintermute.slis.uiowa.edu:8081/ld4l_services/loc_demographics_batch.jsp?{?query}&{?maxRecords}&{?startRecord}&{?lang}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "query",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode": true
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "maxRecords",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "20"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "startRecord",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "1"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "lang",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "en"
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "query":   "query",
+      "start_record": "startRecord",
+      "requested_records": "maxRecords"
+    },
+    "total_count_ldpath": "vivo:count",
+    "results": {
+      "label_ldpath":    "skos:prefLabel ::xsd:string",
+      "sort_ldpath":     "vivo:rank ::xsd:string"
+    },
+    "context": {
+      "groups": {
+        "hierarchy": {
+          "group_label_i18n": "qa.linked_data.authority.locdemographics_ld4l_cache.hierarchy",
+          "group_label_default": "Hierarchy"
+        }
+      },
+      "properties": [
+        {
+          "property_label_i18n": "qa.linked_data.authority.locdemographics_ld4l_cache.preferred_label",
+          "property_label_default": "Preferred label",
+          "ldpath": "skos:prefLabel :: xsd:string",
+          "selectable": true,
+          "drillable": false
+        },
+        {
+          "group_id": "hierarchy",
+          "property_label_i18n": "qa.linked_data.authority.locdemographics_ld4l_cache.broader",
+          "property_label_default": "Broader",
+          "ldpath": "skos:broader :: xsd:string",
+          "selectable": true,
+          "drillable": true,
+          "expansion_label_ldpath": "skos:prefLabel ::xsd:string",
+          "expansion_id_ldpath": "loc:lccn ::xsd:string"
+        },
+        {
+          "group_id": "hierarchy",
+          "property_label_i18n": "qa.linked_data.authority.locdemographics_ld4l_cache.narrower",
+          "property_label_default": "Narrower",
+          "ldpath": "skos:narrower :: xsd:string",
+          "selectable": true,
+          "drillable": true,
+          "expansion_label_ldpath": "skos:prefLabel ::xsd:string",
+          "expansion_id_ldpath": "loc:lccn ::xsd:string"
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.locdemographics_ld4l_cache.variant_label",
+          "property_label_default": "Variant",
+          "ldpath": "madsrdf:hasVariant/madsrdf:variantLabel :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.locdemographics_ld4l_cache.earlier_form",
+          "property_label_default": "Earlier form",
+          "ldpath": "madsrdf:hasEarlierEstablishedForm/madsrdf:authoritativeLabel :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.locdemographics_ld4l_cache.related",
+          "property_label_default": "Related",
+          "ldpath": "skos:related/skos:prefLabel :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.locdemographics_ld4l_cache.note",
+          "property_label_default": "Note",
+          "ldpath": "skos:note :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.locdemographics_ld4l_cache.example",
+          "property_label_default": "Example",
+          "ldpath": "skos:example :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.locdemographics_ld4l_cache.citation_note",
+          "property_label_default": "Citation note",
+          "ldpath": "madsrdf:hasSource/madsrdf:citation-note :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.locdemographics_ld4l_cache.citation_source",
+          "property_label_default": "Citation source",
+          "ldpath": "madsrdf:hasSource/madsrdf:citation-source :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.locdemographics_ld4l_cache.citation_status",
+          "property_label_default": "Citation status",
+          "ldpath": "madsrdf:hasSource/madsrdf:citation-status :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.locdemographics_ld4l_cache.scheme",
+          "property_label_default": "Scheme",
+          "ldpath": "madsrdf:isMemberOfMADSScheme/rdfs:label :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        }
+      ]
+    }
+  }
+}

--- a/config/authorities/linked_data/locgenres_new_ld4l_cache.json
+++ b/config/authorities/linked_data/locgenres_new_ld4l_cache.json
@@ -1,0 +1,207 @@
+{
+  "QA_CONFIG_VERSION": "2.2",
+  "service_uri": "http://ld4l.org/ld4l_services/cache",
+  "prefixes": {
+    "loc":     "http://id.loc.gov/vocabulary/identifiers/",
+    "madsrdf": "http://www.loc.gov/mads/rdf/v1#",
+    "vivo":    "http://vivoweb.org/ontology/core#"
+  },
+  "term": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type":    "IriTemplate",
+      "template": "http://wintermute.slis.uiowa.edu:8081/ld4l_services/loc_genre_lookup.jsp?uri={term_uri}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type":    "IriTemplateMapping",
+          "variable": "term_uri",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode":   true
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "term_id": "term_uri"
+    },
+    "term_id": "URI",
+    "results": {
+      "id_ldpath":       "loc:lccn ::xsd:string",
+      "label_ldpath":    "skos:prefLabel | madsrdf:variantLabel ::xsd:string",
+      "altlabel_ldpath": "skos:altLabel ::xsd:string",
+      "broader_ldpath":  "skos:broader ::xsd:anyURI",
+      "narrower_ldpath": "skos:narrower ::xsd:anyURI",
+      "sameas_ldpath":   "skos:exactMatch ::xsd:anyURI"
+    }
+  },
+  "search": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type": "IriTemplate",
+      "template": "http://wintermute.slis.uiowa.edu:8081/ld4l_services/loc_genre_batch.jsp?{?query}&{?entity}&{?maxRecords}&{?startRecord}&{?lang}&{?context}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "query",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode": true
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "entity",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": ""
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "maxRecords",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "20"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "startRecord",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "1"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "lang",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "en"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "context",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "false"
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "query":   "query",
+      "subauth": "entity",
+      "start_record": "startRecord",
+      "requested_records": "maxRecords"
+    },
+    "total_count_ldpath": "vivo:count",
+    "results": {
+      "id_ldpath":    "loc:lccn ::xsd:string",
+      "label_ldpath": "skos:prefLabel | madsrdf:variantLabel ::xsd:string",
+      "sort_ldpath":  "vivo:rank ::xsd:string"
+    },
+    "context": {
+      "groups": {
+        "hierarchy": {
+          "group_label_i18n": "qa.linked_data.authority.locgenres_ld4l_cache.hierarchy",
+          "group_label_default": "Hierarchy"
+        },
+        "deprecation": {
+          "group_label_i18n": "qa.linked_data.authority.locgenres_ld4l_cache.deprecation",
+          "group_label_default": "Deprecation"
+        }
+      },
+      "properties": [
+        {
+          "property_label_i18n": "qa.linked_data.authority.locgenres_ld4l_cache.preferred_label",
+          "property_label_default": "Preferred label",
+          "ldpath": "skos:prefLabel | madsrdf:variantLabel :: xsd:string",
+          "selectable": true,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.locgenres_ld4l_cache.alt_label",
+          "property_label_default": "Alternative Label",
+          "ldpath": "skos:altLabel :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.locgenres_ld4l_cache.scope_note",
+          "property_label_default": "Scope note",
+          "ldpath": "skos:note :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.locgenres_ld4l_cache.citation_note",
+          "property_label_default": "Citation note",
+          "ldpath": "madsrdf:hasSource / madsrdf:citation-note :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.locgenres_ld4l_cache.citation_source",
+          "property_label_default": "Citation source",
+          "ldpath": "madsrdf:hasSource / madsrdf:citation-source :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.locgenres_ld4l_cache.citation_status",
+          "property_label_default": "Citation status",
+          "ldpath": "madsrdf:hasSource / madsrdf:citation-status :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "group_id": "hierarchy",
+          "property_label_i18n": "qa.linked_data.authority.locgenres_ld4l_cache.broader",
+          "property_label_default": "Broader",
+          "ldpath": "skos:broader :: xsd:string",
+          "selectable": true,
+          "drillable": true,
+          "expansion_label_ldpath": "skos:prefLabel ::xsd:string",
+          "expansion_id_ldpath": "loc:lccn ::xsd:string"
+        },
+        {
+          "group_id": "hierarchy",
+          "property_label_i18n": "qa.linked_data.authority.locgenres_ld4l_cache.narrower",
+          "property_label_default": "Narrower",
+          "ldpath": "skos:narrower :: xsd:string",
+          "selectable": true,
+          "drillable": true,
+          "expansion_label_ldpath": "skos:prefLabel ::xsd:string",
+          "expansion_id_ldpath": "loc:lccn ::xsd:string"
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.locgenres_ld4l_cache.type",
+          "property_label_default": "Type",
+          "ldpath": "rdf:type :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "group_id": "deprecation",
+          "property_label_i18n": "qa.linked_data.authority.locgenres_ld4l_cache.use_instead",
+          "property_label_default": "Use instead",
+          "ldpath": "madsrdf:useInstead :: xsd:string",
+          "selectable": true,
+          "drillable": true,
+          "expansion_label_ldpath": "skos:prefLabel ::xsd:string",
+          "expansion_id_ldpath": "loc:lccn ::xsd:string"
+        },
+        {
+          "group_id": "deprecation",
+          "property_label_i18n": "qa.linked_data.authority.locgenres_ld4l_cache.deletion_note",
+          "property_label_default": "Deletion note",
+          "ldpath": "madsrdf:deletionNote :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        }
+      ]
+    },
+    "subauthorities": {
+      "active":       "active",
+      "deprecated":   "deprecated"
+    }
+  }
+}

--- a/config/authorities/linked_data/locnames_new_ld4l_cache.json
+++ b/config/authorities/linked_data/locnames_new_ld4l_cache.json
@@ -1,0 +1,176 @@
+{
+  "QA_CONFIG_VERSION": "2.2",
+  "service_uri": "http://ld4l.org/ld4l_services/cache",
+  "prefixes": {
+    "loc":     "http://id.loc.gov/vocabulary/identifiers/",
+    "madsrdf": "http://www.loc.gov/mads/rdf/v1#",
+    "vivo":    "http://vivoweb.org/ontology/core#"
+  },
+  "term": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type":    "IriTemplate",
+      "template": "http://wintermute.slis.uiowa.edu:8081/ld4l_services/loc_name_lookup.jsp?uri={term_uri}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type":    "IriTemplateMapping",
+          "variable": "term_uri",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode":   true
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "term_id": "term_uri"
+    },
+    "term_id": "URI",
+    "results": {
+      "id_ldpath":       "loc:lccn ::xsd:string",
+      "label_ldpath":    "madsrdf:authoritativeLabel ::xsd:string",
+      "altlabel_ldpath": "madsrdf:hasVariant/madsrdf:variantLabel ::xsd:string",
+      "sameas_ldpath":   "skos:exactMatch ::xsd:anyURI"
+    }
+  },
+  "search": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type": "IriTemplate",
+      "template": "http://wintermute.slis.uiowa.edu:8081/ld4l_services/loc_name_batch.jsp?{?query}&{?maxRecords}&{?startRecord}&{?entity}&{?lang}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "query",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode": true
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "entity",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": ""
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "maxRecords",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "20"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "startRecord",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "1"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "lang",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "en"
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "query":   "query",
+      "subauth": "entity",
+      "start_record": "startRecord",
+      "requested_records": "maxRecords"
+    },
+    "total_count_ldpath": "vivo:count",
+    "results": {
+      "id_ldpath":    "loc:lccn ::xsd:string",
+      "label_ldpath": "madsrdf:authoritativeLabel ::xsd:string",
+      "sort_ldpath":  "vivo:rank ::xsd:string"
+    },
+    "context": {
+      "groups": {
+        "dates": {
+          "group_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.dates",
+          "group_label_default": "Dates"
+        },
+        "places": {
+          "group_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.places",
+          "group_label_default": "Places"
+        }
+      },
+      "properties": [
+        {
+          "property_label_default": "Preferred label",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.type_label",
+          "ldpath": "madsrdf:authoritativeLabel :: xsd:string",
+          "selectable": true,
+          "drillable": false
+        },
+        {
+          "property_label_default": "Type",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.type_label",
+          "ldpath": "rdf:type :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_default": "Variant label",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.variant_label",
+          "ldpath": "madsrdf:hasVariant/madsrdf:variantLabel :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_default": "Citation note",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.citation_note",
+          "ldpath": "madsrdf:hasSource/madsrdf:citation-note :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_default": "Citation source",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.citation_source",
+          "ldpath": "madsrdf:hasSource/madsrdf:citation-source :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_default": "Citation status",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.citation_status",
+          "ldpath": "madsrdf:hasSource/madsrdf:citation-status :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_default": "Earlier established form",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.ealier_established_form",
+          "ldpath": "madsrdf:hasEarlierEstablishedForm/madsrdf:authoritativeLabel :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["conference"]
+        },
+        {
+          "property_label_default": "Later established form",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.later_established_form",
+          "ldpath": "madsrdf:hasLaterEstablishedForm/madsrdf:authoritativeLabel :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["conference"]
+        },
+        {
+          "property_label_default": "Editorial note",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.editorial_note",
+          "ldpath": "madsrdf:editorialNote :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        }
+      ]
+    },
+    "subauthorities": {
+      "geographic":     "Geographic",
+      "conference":     "ConferenceName"
+    }
+  }
+}

--- a/config/authorities/linked_data/locnames_new_rwo_ld4l_cache.json
+++ b/config/authorities/linked_data/locnames_new_rwo_ld4l_cache.json
@@ -1,0 +1,248 @@
+{
+  "QA_CONFIG_VERSION": "2.2",
+  "service_uri": "http://ld4l.org/ld4l_services/cache",
+  "prefixes": {
+    "loc":     "http://id.loc.gov/vocabulary/identifiers/",
+    "madsrdf": "http://www.loc.gov/mads/rdf/v1#",
+    "vivo":    "http://vivoweb.org/ontology/core#"
+  },
+  "term": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type":    "IriTemplate",
+      "template": "http://wintermute.slis.uiowa.edu:8081/ld4l_services/loc_rwo_name_lookup.jsp?uri={term_uri}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type":    "IriTemplateMapping",
+          "variable": "term_uri",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode":   true
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "term_id": "term_uri"
+    },
+    "term_id": "URI",
+    "results": {
+      "id_ldpath":       "^madsrdf:identifiesRWO/loc:lccn ::xsd:string",
+      "label_ldpath":    "rdfs:label ::xsd:string",
+      "altlabel_ldpath": "^madsrdf:identifiesRWO/madsrdf:hasVariant/madsrdf:variantLabel :: xsd:string",
+      "sameas_ldpath":   "skos:exactMatch ::xsd:anyURI"
+    }
+  },
+  "search": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type": "IriTemplate",
+      "template": "http://wintermute.slis.uiowa.edu:8081/ld4l_services/loc_rwo_name_batch.jsp?{?query}&{?maxRecords}&{?startRecord}&{?entity}&{?lang}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "query",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode": true
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "entity",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": ""
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "maxRecords",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "20"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "startRecord",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "1"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "lang",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "en"
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "query":   "query",
+      "subauth": "entity",
+      "start_record": "startRecord",
+      "requested_records": "maxRecords"
+    },
+    "total_count_ldpath": "vivo:count",
+    "results": {
+      "id_ldpath":    "^madsrdf:identifiesRWO/loc:lccn ::xsd:string",
+      "label_ldpath": "rdfs:label ::xsd:string",
+      "sort_ldpath":  "vivo:rank ::xsd:string"
+    },
+    "context": {
+      "groups": {
+        "dates": {
+          "group_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.dates",
+          "group_label_default": "Dates"
+        },
+        "places": {
+          "group_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.places",
+          "group_label_default": "Places"
+        }
+      },
+      "properties": [
+        {
+          "property_label_default": "Preferred label",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.type_label",
+          "ldpath": "rdfs:label :: xsd:string",
+          "selectable": true,
+          "drillable": false
+        },
+        {
+          "property_label_default": "Type",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.type_label",
+          "ldpath": "rdf:type :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_default": "Descriptor",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.type_label",
+          "ldpath": "(madsrdf:entityDescriptor/madsrdf:authoritativeLabel) | (madsrdf:entityDescriptor/skos:prefLabel) | (madsrdf:entityDescriptor/rdfs:label) :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person", "organization"]
+        },
+        {
+          "group_id": "dates",
+          "property_label_default": "Birth date",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.birth_date",
+          "ldpath": "madsrdf:birthDate/rdfs:label :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "optional": true,
+          "subauth": ["person"]
+        },
+        {
+          "group_id": "dates",
+          "property_label_default": "Death date",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.death_date",
+          "ldpath": "madsrdf:deathDate/rdfs:label :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person"]
+        },
+        {
+          "group_id": "places",
+          "property_label_default": "Location",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.location",
+          "ldpath": "(madsrdf:associatedLocale/skos:prefLabel) | (madsrdf:associatedLocale/rdfs:label) :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["organization", "family"]
+        },
+        {
+          "property_label_default": "Affiliation",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.field_of_activity",
+          "ldpath": "(madsrdf:hasAffiliation/madsrdf:organization/skos:prefLabel) | (madsrdf:hasAffiliation/madsrdf:organization/rdfs:label) | (madsrdf:hasAffiliation/madsrdf:organization/madsrdf:authoritativeLabel) :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person", "organization"]
+        },
+        {
+          "property_label_default": "Field of activity",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.field_of_activity",
+          "ldpath": "(madsrdf:fieldOfActivity/skos:prefLabel) | (madsrdf:fieldOfActivity/rdfs:label) :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person", "organization"]
+        },
+        {
+          "property_label_default": "Occupation",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.occupation",
+          "ldpath": "(madsrdf:occupation/skos:prefLabel) | (madsrdf:occupation/rdfs:label) | (madsrdf:occupation/madsrdf:authoritativeLabel) :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person", "organization"]
+        },
+        {
+          "group_id": "places",
+          "property_label_default": "Birth place",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.birth_place",
+          "ldpath": "(madsrdf:birthPlace/skos:prefLabel) | (madsrdf:birthPlace/rdfs:label) :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person"]
+        },
+        {
+          "group_id": "places",
+          "property_label_default": "Death place",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.death_place",
+          "ldpath": "(madsrdf:deathPlace/skos:prefLabel) | (madsrdf:deathPlace/rdfs:label) :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person"]
+        },
+        {
+          "property_label_default": "VIAF match",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.viaf_match",
+          "ldpath": "^madsrdf:identifiesRWO/skos:exactMatch :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person", "organization"]
+        },
+        {
+          "property_label_default": "Variant label",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.variant_label",
+          "ldpath": "^madsrdf:identifiesRWO/madsrdf:hasVariant/madsrdf:variantLabel :: xsd:string",
+          "selectable": false,
+          "drillable": false,
+          "subauth": ["person", "organization"]
+        },
+        {
+          "property_label_default": "Citation note",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.citation_note",
+          "ldpath": "^madsrdf:identifiesRWO/madsrdf:hasSource/madsrdf:citation-note :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_default": "Citation source",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.citation_source",
+          "ldpath": "^madsrdf:identifiesRWO/madsrdf:hasSource/madsrdf:citation-source :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_default": "Editorial note",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.editorial_note",
+          "ldpath": "^madsrdf:identifiesRWO/madsrdf:editorialNote :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_default": "Authority URI",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.authority_uri",
+          "ldpath": "^madsrdf:identifiesRWO :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        }
+      ]
+    },
+    "subauthorities": {
+      "person":         "Person",
+      "organization":   "Organization",
+      "family":         "Family"
+    }
+  }
+}

--- a/config/authorities/linked_data/locperformance_new_ld4l_cache.json
+++ b/config/authorities/linked_data/locperformance_new_ld4l_cache.json
@@ -1,0 +1,149 @@
+{
+  "QA_CONFIG_VERSION": "2.2",
+  "service_uri": "http://ld4l.org/ld4l_services/cache",
+  "prefixes": {
+    "loc":     "http://id.loc.gov/vocabulary/identifiers/",
+    "madsrdf": "http://www.loc.gov/mads/rdf/v1#",
+    "vivo":    "http://vivoweb.org/ontology/core#"
+  },
+  "term": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type":    "IriTemplate",
+      "template": "http://wintermute.slis.uiowa.edu:8081/ld4l_services/loc_performance_lookup.jsp?uri={term_uri}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type":    "IriTemplateMapping",
+          "variable": "term_uri",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode":   true
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "term_id": "term_uri"
+    },
+    "term_id": "URI",
+    "results": {
+      "id_ldpath":       "loc:lccn ::xsd:string",
+      "label_ldpath":    "skos:prefLabel ::xsd:string",
+      "altlabel_ldpath": "skos:altLabel ::xsd:string",
+      "sameas_ldpath":   "skos:exactMatch ::xsd:anyURI"
+    }
+  },
+  "search": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type": "IriTemplate",
+      "template": "http://wintermute.slis.uiowa.edu:8081/ld4l_services/loc_performance_batch.jsp?{?query}&{?maxRecords}&{?startRecord}&{?lang}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "query",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode": true
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "maxRecords",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "20"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "startRecord",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "1"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "lang",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "en"
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "query":   "query",
+      "start_record": "startRecord",
+      "requested_records": "maxRecords"
+    },
+    "total_count_ldpath": "vivo:count",
+    "results": {
+      "label_ldpath": "skos:prefLabel ::xsd:string",
+      "sort_ldpath":  "vivo:rank ::xsd:string"
+    },
+    "context": {
+      "groups": {
+        "hierarchy": {
+          "group_label_i18n": "qa.linked_data.authority.locperformance_ld4l_cache.hierarchy",
+          "group_label_default": "Hierarchy"
+        }
+      },
+      "properties": [
+        {
+          "property_label_i18n": "qa.linked_data.authority.locperformance_ld4l_cache.preferred_label",
+          "property_label_default": "Preferred label",
+          "ldpath": "skos:prefLabel :: xsd:string",
+          "selectable": true,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.locperformance_ld4l_cache.alt_label",
+          "property_label_default": "Alternative Label",
+          "ldpath": "skos:altLabel :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.locperformance_ld4l_cache.citation_note",
+          "property_label_default": "Citation note",
+          "ldpath": "madsrdf:hasSource / madsrdf:citation-note :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.locperformance_ld4l_cache.citation_source",
+          "property_label_default": "Citation source",
+          "ldpath": "madsrdf:hasSource / madsrdf:citation-source :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.locperformance_ld4l_cache.citation_status",
+          "property_label_default": "Citation status",
+          "ldpath": "madsrdf:hasSource / madsrdf:citation-status :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "group_id": "hierarchy",
+          "property_label_i18n": "qa.linked_data.authority.locperformance_ld4l_cache.broader",
+          "property_label_default": "Broader",
+          "ldpath": "skos:broader :: xsd:string",
+          "selectable": true,
+          "drillable": true,
+          "expansion_label_ldpath": "skos:prefLabel ::xsd:string",
+          "expansion_id_ldpath": "loc:lccn ::xsd:string"
+        },
+        {
+          "group_id": "hierarchy",
+          "property_label_i18n": "qa.linked_data.authority.locperformance_ld4l_cache.narrower",
+          "property_label_default": "Narrower",
+          "ldpath": "skos:narrower :: xsd:string",
+          "selectable": true,
+          "drillable": true,
+          "expansion_label_ldpath": "skos:prefLabel ::xsd:string",
+          "expansion_id_ldpath": "loc:lccn ::xsd:string"
+        }
+      ]
+    }
+  }
+}

--- a/config/authorities/linked_data/locsubjects_new_ld4l_cache.json
+++ b/config/authorities/linked_data/locsubjects_new_ld4l_cache.json
@@ -1,0 +1,157 @@
+{
+  "QA_CONFIG_VERSION": "2.2",
+  "service_uri": "http://ld4l.org/ld4l_services/cache",
+  "prefixes": {
+    "loc":     "http://id.loc.gov/vocabulary/identifiers/",
+    "madsrdf": "http://www.loc.gov/mads/rdf/v1#",
+    "vivo":    "http://vivoweb.org/ontology/core#"
+  },
+  "term": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type":    "IriTemplate",
+      "template": "http://wintermute.slis.uiowa.edu:8081/ld4l_services/loc_subject_lookup.jsp?uri={term_uri}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type":    "IriTemplateMapping",
+          "variable": "term_uri",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode":   true
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "term_id": "term_uri"
+    },
+    "term_id": "URI",
+    "results": {
+      "id_ldpath":       "loc:lccn ::xsd:string",
+      "label_ldpath":    "skos:prefLabel ::xsd:string",
+      "altlabel_ldpath": "skos:altLabel ::xsd:string",
+      "sameas_ldpath":   "skos:exactMatch ::xsd:anyURI"
+    }
+  },
+  "search": {
+    "url": {
+      "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+      "@type": "IriTemplate",
+      "template": "http://wintermute.slis.uiowa.edu:8081/ld4l_services/loc_subject_batch.jsp?{?query}&{?maxRecords}&{?startRecord}&{?lang}",
+      "variableRepresentation": "BasicRepresentation",
+      "mapping": [
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "query",
+          "property": "hydra:freetextQuery",
+          "required": true,
+          "encode": true
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "maxRecords",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "20"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "startRecord",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "1"
+        },
+        {
+          "@type": "IriTemplateMapping",
+          "variable": "lang",
+          "property": "hydra:freetextQuery",
+          "required": false,
+          "default": "en"
+        }
+      ]
+    },
+    "qa_replacement_patterns": {
+      "query":   "query",
+      "subauth": "entity",
+      "start_record": "startRecord",
+      "requested_records": "maxRecords"
+    },
+    "total_count_ldpath": "vivo:count",
+    "results": {
+      "label_ldpath": "madsrdf:authoritativeLabel ::xsd:string",
+      "sort_ldpath":  "vivo:rank ::xsd:string"
+    },
+    "context": {
+      "groups": {
+        "hierarchy": {
+          "group_label_i18n": "qa.linked_data.authority.locsubjects_ld4l_cache.hierarchy",
+          "group_label_default": "Hierarchy"
+        }
+      },
+      "properties": [
+        {
+          "property_label_i18n": "qa.linked_data.authority.locsubjects_ld4l_cache.preferred_label",
+          "property_label_default": "Preferred label",
+          "ldpath": "skos:prefLabel :: xsd:string",
+          "selectable": true,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.locsubjects_ld4l_cache.alternative_label",
+          "property_label_default": "Alternative label",
+          "ldpath": "skos:altLabel :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.locsubjects_ld4l_cache.type",
+          "property_label_default": "Type",
+          "ldpath": "rdf:type :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "group_id": "hierarchy",
+          "property_label_i18n": "qa.linked_data.authority.locsubjects_ld4l_cache.broader",
+          "property_label_default": "Broader",
+          "ldpath": "skos:broader :: xsd:string",
+          "selectable": true,
+          "drillable": true,
+          "expansion_label_ldpath": "skos:prefLabel ::xsd:string",
+          "expansion_id_ldpath": "loc:lccn ::xsd:string"
+        },
+        {
+          "group_id": "hierarchy",
+          "property_label_i18n": "qa.linked_data.authority.locsubjects_ld4l_cache.narrower",
+          "property_label_default": "Narrower",
+          "ldpath": "skos:narrower :: xsd:string",
+          "selectable": true,
+          "drillable": true,
+          "expansion_label_ldpath": "skos:prefLabel ::xsd:string",
+          "expansion_id_ldpath": "loc:lccn ::xsd:string"
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.locsubjects_ld4l_cache.citation_note",
+          "property_label_default": "Citation note",
+          "ldpath": "madsrdf:hasSource / madsrdf:citation-note :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.locsubjects_ld4l_cache.citation_source",
+          "property_label_default": "Citation source",
+          "ldpath": "madsrdf:hasSource / madsrdf:citation-source :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        },
+        {
+          "property_label_i18n": "qa.linked_data.authority.locsubjects_ld4l_cache.citation_status",
+          "property_label_default": "Citation status",
+          "ldpath": "madsrdf:hasSource / madsrdf:citation-status :: xsd:string",
+          "selectable": false,
+          "drillable": false
+        }
+      ]
+    }
+  }
+}

--- a/config/authorities/linked_data/scenarios/dbpedia_ld4l_cache_validation.yml
+++ b/config/authorities/linked_data/scenarios/dbpedia_ld4l_cache_validation.yml
@@ -23,6 +23,18 @@ search:
     subject_uri: "http://dbpedia.org/resource/Volleyball"
     replacements:
       maxRecords: '10'
+  -
+    query: Volleyb
+    position: 5
+    subject_uri: "http://dbpedia.org/resource/Volleyball"
+    replacements:
+      maxRecords: '10'
+  -
+    query: volleyb
+    position: 5
+    subject_uri: "http://dbpedia.org/resource/Volleyball"
+    replacements:
+      maxRecords: '10'
 term:
   -
     identifier: 'http://dbpedia.org/resource/Barack_Obama'

--- a/config/authorities/linked_data/scenarios/locdemographics_ld4l_cache_validation.yml
+++ b/config/authorities/linked_data/scenarios/locdemographics_ld4l_cache_validation.yml
@@ -19,11 +19,23 @@ search:
     replacements:
       maxRecords: '5'
   -
-    query: Biologists
-    position: 10
-    subject_uri: "http://id.loc.gov/authorities/demographicTerms/dg2016060468"
+    query: Biologist
+    position: 3
+    subject_uri: "http://id.loc.gov/authorities/demographicTerms/dg2015060613"
     replacements:
-      maxRecords: '20'
+      maxRecords: '5'
+  -
+    query: social worker
+    position: 1
+    subject_uri: "http://id.loc.gov/authorities/demographicTerms/dg2015060087"
+    replacements:
+      maxRecords: '10'
+  -
+    query: Social Worker
+    position: 1
+    subject_uri: "http://id.loc.gov/authorities/demographicTerms/dg2015060087"
+    replacements:
+      maxRecords: '10'
   -
     query: Kiwis
     position: 1
@@ -46,6 +58,12 @@ search:
     query: African Americans
     position: 5
     subject_uri: "http://id.loc.gov/authorities/demographicTerms/dg2015060859"
+    replacements:
+      maxRecords: '10'
+  -
+    query: dancers
+    position: 3
+    subject_uri: "http://id.loc.gov/authorities/demographicTerms/dg2015060747"
     replacements:
       maxRecords: '10'
   -

--- a/config/authorities/linked_data/scenarios/locdemographics_new_ld4l_cache_validation.yml
+++ b/config/authorities/linked_data/scenarios/locdemographics_new_ld4l_cache_validation.yml
@@ -1,0 +1,78 @@
+---
+authority:
+  service: ld4l_cache
+  context: true
+search:
+  #------------------
+  # Connection tests
+  #------------------
+  -
+    query: workers
+  #------------------
+  #  Accuracy tests
+  #------------------
+  # No subauths (yet, perhaps at some point we'll have to deal with madsrdf:DeprecatedAuthority)
+  -
+    query: Biologists
+    position: 1
+    subject_uri: "http://id.loc.gov/authorities/demographicTerms/dg2015060613"
+    replacements:
+      maxRecords: '5'
+  -
+    query: Biologist
+    position: 3
+    subject_uri: "http://id.loc.gov/authorities/demographicTerms/dg2015060613"
+    replacements:
+      maxRecords: '5'
+  -
+    query: social worker
+    position: 1
+    subject_uri: "http://id.loc.gov/authorities/demographicTerms/dg2015060087"
+    replacements:
+      maxRecords: '10'
+  -
+    query: Social Worker
+    position: 1
+    subject_uri: "http://id.loc.gov/authorities/demographicTerms/dg2015060087"
+    replacements:
+      maxRecords: '10'
+  -
+    query: Kiwis
+    position: 1
+    subject_uri: "http://id.loc.gov/authorities/demographicTerms/dg2015060357"
+    replacements:
+      maxRecords: '5'
+  -
+    query: New Zealanders
+    position: 8
+    subject_uri: "http://id.loc.gov/authorities/demographicTerms/dg2016060205"
+    replacements:
+      maxRecords: '15'
+  -
+    query: New Zealanders
+    position: 8
+    subject_uri: "http://id.loc.gov/authorities/demographicTerms/dg2015060330"
+    replacements:
+      maxRecords: '15'
+  -
+    query: African Americans
+    position: 5
+    subject_uri: "http://id.loc.gov/authorities/demographicTerms/dg2015060859"
+    replacements:
+      maxRecords: '10'
+  -
+    query: dancers
+    position: 3
+    subject_uri: "http://id.loc.gov/authorities/demographicTerms/dg2015060747"
+    replacements:
+      maxRecords: '10'
+  -
+    query: Micmac
+    position: 1
+    subject_uri: "http://id.loc.gov/authorities/demographicTerms/dg2016060011"
+    replacements:
+      maxRecords: '5'
+term:
+  -
+    identifier: 'http://id.loc.gov/authorities/demographicTerms/dg2015060460'
+

--- a/config/authorities/linked_data/scenarios/locgenres_new_ld4l_cache_validation.yml
+++ b/config/authorities/linked_data/scenarios/locgenres_new_ld4l_cache_validation.yml
@@ -1,0 +1,128 @@
+# Supported subauthorities:
+#   active
+#   deprecated
+---
+authority:
+  service: ld4l_cache
+  context: true
+search:
+  #------------------
+  # Connection tests
+  #------------------
+  -
+    query: animation
+  -
+    query: Basketball television programs
+  -
+    query: animation
+    subauth: active
+  -
+    query: Basketball television programs
+    subauth: deprecated
+  #------------------
+  #  Accuracy tests
+  #------------------
+  #    active
+  -
+    query: Preliminary documents (Treaties)
+    position: 10
+    subject_uri: "http://id.loc.gov/authorities/genreForms/gf2011026703"
+    replacements:
+      maxRecords: '20'
+  -
+    query: maps
+    position: 3
+    subject_uri: "http://id.loc.gov/authorities/genreForms/gf2011026387"
+    replacements:
+      maxRecords: '10'
+  -
+    query: Loose-leafs
+    position: 10
+    subject_uri: "http://id.loc.gov/authorities/genreForms/gf2011026373"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Casebooks (Law)
+    position: 3
+    subject_uri: "http://id.loc.gov/authorities/genreForms/gf2011026115"
+    replacements:
+      maxRecords: '10'
+  -
+    query: Casebooks
+    position: 10
+    subject_uri: "http://id.loc.gov/authorities/genreForms/gf2011026115"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Congresses, Conferences, Proceedings, Symposia
+    position: 10
+    subject_uri: "http://id.loc.gov/authorities/genreForms/gf2014026068"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Law journals
+    position: 10
+    subject_uri: "http://id.loc.gov/authorities/genreForms/gf2011026352"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Codes
+    position: 10
+    subject_uri: "http://id.loc.gov/authorities/genreForms/gf2011026611"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Administrative rules
+    position: 10
+    subject_uri: "http://id.loc.gov/authorities/genreForms/gf2011026030"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Conventions
+    position: 10
+    subject_uri: "http://id.loc.gov/authorities/genreForms/gf2011026707"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Digests
+    position: 10
+    subject_uri: "http://id.loc.gov/authorities/genreForms/gf2011026349"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Law reports
+    position: 10
+    subject_uri: "http://id.loc.gov/authorities/genreForms/gf2011026172"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Interstate compacts
+    position: 10
+    subject_uri: "http://id.loc.gov/authorities/genreForms/gf2011026336"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Noter-ups
+    position: 10
+    subject_uri: "http://id.loc.gov/authorities/genreForms/gf2011026136"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Basketball television programs
+    subauth: deprecated
+    position: 10
+    subject_uri: "http://id.loc.gov/authorities/genreForms/gf2011026080"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Cookery
+    subauth: deprecated
+    position: 10
+    subject_uri: "http://id.loc.gov/authorities/subjects/sh2010025047"
+    replacements:
+      maxRecords: '20'
+term:
+  -
+    identifier: "http://id.loc.gov/authorities/genreForms/gf2011026141"
+  -
+    identifier: "http://id.loc.gov/authorities/genreForms/gf2011026080"

--- a/config/authorities/linked_data/scenarios/locnames_ld4l_cache_validation.yml
+++ b/config/authorities/linked_data/scenarios/locnames_ld4l_cache_validation.yml
@@ -34,10 +34,31 @@ search:
     replacements:
       maxRecords: '20'
   -
+    query: Boston Mass
+    position: 5
+    subauth: geographic
+    subject_uri: "http://id.loc.gov/authorities/names/n79045553"
+    replacements:
+      maxRecords: '10'
+  -
     query: Madrid, Spain
     position: 5
     subauth: geographic
     subject_uri: "http://id.loc.gov/authorities/names/n78089046"
+    replacements:
+      maxRecords: '15'
+  -
+    query: seattle
+    position: 5
+    subauth: geographic
+    subject_uri: "http://id.loc.gov/authorities/names/n79041965"
+    replacements:
+      maxRecords: '15'
+  -
+    query: seattle (wash.)
+    position: 5
+    subauth: geographic
+    subject_uri: "http://id.loc.gov/authorities/names/n79041965"
     replacements:
       maxRecords: '15'
   -

--- a/config/authorities/linked_data/scenarios/locnames_new_ld4l_cache_validation.yml
+++ b/config/authorities/linked_data/scenarios/locnames_new_ld4l_cache_validation.yml
@@ -1,0 +1,73 @@
+# Supported subauthorities:
+#   geographic
+#   conference
+---
+authority:
+  service: ld4l_cache
+  context: true
+search:
+  #------------------
+  # Connection tests
+  #------------------
+  -
+    query: Boston Mass
+    position: 3
+    subject_uri: "http://id.loc.gov/authorities/names/n79045553"
+    replacements:
+      maxRecords: '10'
+  -
+    query: Cayuga
+  -
+    query: Cayuga
+    subauth: geographic
+  -
+    query: ALA
+    subauth: conference
+  #------------------
+  #  Accuracy tests
+  #------------------
+  -
+    query: Camden NJ
+    position: 8
+    subauth: geographic
+    subject_uri: "http://id.loc.gov/authorities/names/n81139356"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Boston Mass
+    position: 5
+    subauth: geographic
+    subject_uri: "http://id.loc.gov/authorities/names/n79045553"
+    replacements:
+      maxRecords: '10'
+  -
+    query: Madrid, Spain
+    position: 5
+    subauth: geographic
+    subject_uri: "http://id.loc.gov/authorities/names/n78089046"
+    replacements:
+      maxRecords: '15'
+  -
+    query: seattle
+    position: 5
+    subauth: geographic
+    subject_uri: "http://id.loc.gov/authorities/names/n79041965"
+    replacements:
+      maxRecords: '15'
+  -
+    query: seattle (wash.)
+    position: 5
+    subauth: geographic
+    subject_uri: "http://id.loc.gov/authorities/names/n79041965"
+    replacements:
+      maxRecords: '15'
+  -
+    query: Non Food Uses of Crops
+    position: 5
+    subauth: conference
+    subject_uri: "http://id.loc.gov/authorities/names/nb2014001245"
+    replacements:
+      maxRecords: '15'
+term:
+  -
+    identifier: 'http://id.loc.gov/authorities/names/n92016188'

--- a/config/authorities/linked_data/scenarios/locnames_new_rwo_ld4l_cache_validation.yml
+++ b/config/authorities/linked_data/scenarios/locnames_new_rwo_ld4l_cache_validation.yml
@@ -1,0 +1,211 @@
+# Supported subauthorities:
+#   person
+#   organization
+#   family
+---
+authority:
+  service: ld4l_cache
+  context: true
+search:
+  #------------------
+  # Connection tests
+  #------------------
+  -
+    query: 'mark twain'
+  -
+    query: 'Twain, Mark, 1835-1910'
+    subauth: person
+  -
+    query: 'mark twain'
+    subauth: organization
+  -
+    query: 'twain'
+    subauth: family
+  #------------------
+  #  Accuracy tests
+  #------------------
+  -
+    query: Twain, Mark, 1835-1910
+    subauth: person
+    position: 1
+    subject_uri: "http://id.loc.gov/rwo/agents/n79021164"
+    replacements:
+      maxRecords: '10'
+  -
+    query: Camden, William
+    subauth: person
+    position: 10
+    subject_uri: "http://id.loc.gov/rwo/agents/n50031528"
+    replacements:
+      maxRecords: '20'
+  -
+    query: King Stephen 1947
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79063767"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Tweedy, Jeff
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/no98126226"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Tanaka, Shōzō
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n81047749"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Tanaka, Shozo
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n81047749"
+    replacements:
+      maxRecords: '20'
+  -
+    query: 田中正造
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n81047749"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Endalageta Kabada
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/no2003094541"
+    replacements:
+      maxRecords: '20'
+  -
+    query: ʼEndālagétā Kabada
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/no2003094541"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Tolstoy, Leo
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
+    replacements:
+      maxRecords: '20'
+  -
+    query: tolstoi, lev
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Tolstoĭ, Lev
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Толстой, Лев
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Толстой, Лев, граф, 1828-1910
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
+    replacements:
+      maxRecords: '20'
+  -
+    query: טאלסטאי, ליעװ
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
+    replacements:
+      maxRecords: '20'
+  -
+    query: レオ.トルストイ
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
+    replacements:
+      maxRecords: '20'
+  -
+    query: لئون تولستوى
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
+    replacements:
+      maxRecords: '20'
+  -
+    query: 托爾斯泰, 列夫
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
+    replacements:
+      maxRecords: '20'
+  -
+    query: ACLU
+    subauth: organization
+    position: 20
+    subject_uri: "http://id.loc.gov/rwo/agents/n79079580"
+    replacements:
+      maxRecords: '30'
+  -
+    query: University of Pennsylvania
+    subauth: organization
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79065482"
+    replacements:
+      maxRecords: '20'
+  -
+    query: university of pennsylvania
+    subauth: organization
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79065482"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Planned Parenthood Federation of America
+    subauth: organization
+    position: 10
+    subject_uri: "http://id.loc.gov/rwo/agents/n50075375"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Genkai Shosetsu Kenkyukai
+    subauth: organization
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n2013003006"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Genkai Shōsetsu Kenkyūkai
+    subauth: organization
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n2013003006"
+    replacements:
+      maxRecords: '20'
+  -
+    query: 限界小說研究会
+    subauth: organization
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n2013003006"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Waterman Family
+    subauth: family
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n2012043300"
+    replacements:
+      maxRecords: '10'
+term:
+  -
+    identifier: 'http://id.loc.gov/rwo/agents/n79021164'

--- a/config/authorities/linked_data/scenarios/locnames_rwo_ld4l_cache_validation.yml
+++ b/config/authorities/linked_data/scenarios/locnames_rwo_ld4l_cache_validation.yml
@@ -53,6 +53,104 @@ search:
     replacements:
       maxRecords: '20'
   -
+    query: Tanaka, Shōzō
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n81047749"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Tanaka, Shozo
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n81047749"
+    replacements:
+      maxRecords: '20'
+  -
+    query: 田中正造
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n81047749"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Endalageta Kabada
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/no2003094541"
+    replacements:
+      maxRecords: '20'
+  -
+    query: ʼEndālagétā Kabada
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/no2003094541"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Tolstoy, Leo
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
+    replacements:
+      maxRecords: '20'
+  -
+    query: tolstoi, lev
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Tolstoĭ, Lev
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Толстой, Лев
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Толстой, Лев, граф, 1828-1910
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
+    replacements:
+      maxRecords: '20'
+  -
+    query: טאלסטאי, ליעװ
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
+    replacements:
+      maxRecords: '20'
+  -
+    query: レオ.トルストイ
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
+    replacements:
+      maxRecords: '20'
+  -
+    query: لئون تولستوى
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
+    replacements:
+      maxRecords: '20'
+  -
+    query: 托爾斯泰, 列夫
+    subauth: person
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79068416"
+    replacements:
+      maxRecords: '20'
+  -
     query: ACLU
     subauth: organization
     position: 20
@@ -60,10 +158,45 @@ search:
     replacements:
       maxRecords: '30'
   -
+    query: University of Pennsylvania
+    subauth: organization
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79065482"
+    replacements:
+      maxRecords: '20'
+  -
+    query: university of pennsylvania
+    subauth: organization
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n79065482"
+    replacements:
+      maxRecords: '20'
+  -
     query: Planned Parenthood Federation of America
     subauth: organization
     position: 10
     subject_uri: "http://id.loc.gov/rwo/agents/n50075375"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Genkai Shosetsu Kenkyukai
+    subauth: organization
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n2013003006"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Genkai Shōsetsu Kenkyūkai
+    subauth: organization
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n2013003006"
+    replacements:
+      maxRecords: '20'
+  -
+    query: 限界小說研究会
+    subauth: organization
+    position: 5
+    subject_uri: "http://id.loc.gov/rwo/agents/n2013003006"
     replacements:
       maxRecords: '20'
   -

--- a/config/authorities/linked_data/scenarios/locperformance_new_ld4l_cache_validation.yml
+++ b/config/authorities/linked_data/scenarios/locperformance_new_ld4l_cache_validation.yml
@@ -1,0 +1,94 @@
+---
+authority:
+  service: ld4l_cache
+  context: true
+search:
+  #------------------
+  # Connection tests
+  #------------------
+  -
+    query: band
+  #------------------
+  #  Accuracy tests
+  #------------------
+  -
+    query: conductor
+    position: 10
+    subject_uri: "http://id.loc.gov/authorities/performanceMediums/mp2013015171"
+    replacements:
+      maxRecords: '20'
+  -
+    query: tāshā
+    position: 10
+    subject_uri: "http://id.loc.gov/authorities/performanceMediums/mp2013015718"
+    replacements:
+      maxRecords: '20'
+  -
+    query: instrumental ensemble
+    position: 10
+    subject_uri: "http://id.loc.gov/authorities/performanceMediums/mp2013015812"
+    replacements:
+      maxRecords: '20'  
+  -
+    query: tʻaepʻyŏngso
+    position: 10
+    subject_uri: "http://id.loc.gov/authorities/performanceMediums/mp2013015693"
+    replacements:
+      maxRecords: '20'  
+  -
+    query: bassoon
+    position: 10
+    subject_uri: "http://id.loc.gov/authorities/performanceMediums/mp2013015074"
+    replacements:
+      maxRecords: '20'  
+  -
+    query: continuo
+    position: 10
+    subject_uri: "http://id.loc.gov/authorities/performanceMediums/mp2013015173"
+    replacements:
+      maxRecords: '20'  
+  -
+    query: pin peat
+    position: 10
+    subject_uri: "http://id.loc.gov/authorities/performanceMediums/mp2014015025"
+    replacements:
+      maxRecords: '20'
+  -
+    query: solo vocal ensemble
+    position: 10
+    subject_uri: "http://id.loc.gov/authorities/performanceMediums/mp2013015841"
+    replacements:
+      maxRecords: '20'      
+  -
+    query: MIDI controller
+    position: 10
+    subject_uri: "http://id.loc.gov/authorities/performanceMediums/mp2013015474"
+    replacements:
+      maxRecords: '20'  
+  -
+    query: heliphon
+    position: 10
+    subject_uri: "http://id.loc.gov/authorities/performanceMediums/mp2013015339"
+    replacements:
+      maxRecords: '20'  
+  -
+    query: singing bowl
+    position: 10
+    subject_uri: "http://id.loc.gov/authorities/performanceMediums/mp2013015647"
+    replacements:
+      maxRecords: '20'  
+  -
+    query: alto saxophone
+    position: 10
+    subject_uri: "http://id.loc.gov/authorities/performanceMediums/mp2013015015"
+    replacements:
+      maxRecords: '20'      
+  -
+    query: spoils of war (musical instrument)
+    position: 10
+    subject_uri: "http://id.loc.gov/authorities/performanceMediums/mp2016015015"
+    replacements:
+      maxRecords: '20' 
+term:
+  -
+    identifier: 'http://id.loc.gov/authorities/performanceMediums/mp2013015793'

--- a/config/authorities/linked_data/scenarios/locsubjects_ld4l_cache_validation.yml
+++ b/config/authorities/linked_data/scenarios/locsubjects_ld4l_cache_validation.yml
@@ -18,9 +18,27 @@ search:
     replacements:
       maxRecords: '20'
   -
+    query: Guitar music Heavy metal # example of LCSH with parentheses
+    position: 5
+    subject_uri: "http://id.loc.gov/authorities/subjects/sh85059850"
+    replacements:
+      maxRecords: '10'
+  -
     query: Cooking with bacon
     position: 7
     subject_uri: "http://id.loc.gov/authorities/subjects/sh85031944"
+    replacements:
+      maxRecords: '20'
+  -
+    query: History
+    position: 5
+    subject_uri: "http://id.loc.gov/authorities/subjects/sh85061212"
+    replacements:
+      maxRecords: '20'
+  -
+    query: History
+    position: 5
+    subject_uri: "http://id.loc.gov/authorities/subjects/sh85061212"
     replacements:
       maxRecords: '20'
 term:

--- a/config/authorities/linked_data/scenarios/locsubjects_new_ld4l_cache_validation.yml
+++ b/config/authorities/linked_data/scenarios/locsubjects_new_ld4l_cache_validation.yml
@@ -1,0 +1,46 @@
+---
+authority:
+  service: ld4l_cache
+  context: true
+search:
+  #------------------
+  # Connection tests
+  #------------------
+  -
+    query: science
+  #------------------
+  #  Accuracy tests
+  #------------------
+  -
+    query: Guitar music (Heavy metal) # example of LCSH with parentheses
+    position: 10
+    subject_uri: "http://id.loc.gov/authorities/subjects/sh85059850"
+    replacements:
+      maxRecords: '20'
+  -
+    query: Guitar music Heavy metal # example of LCSH with parentheses
+    position: 5
+    subject_uri: "http://id.loc.gov/authorities/subjects/sh85059850"
+    replacements:
+      maxRecords: '10'
+  -
+    query: Cooking with bacon
+    position: 7
+    subject_uri: "http://id.loc.gov/authorities/subjects/sh85031944"
+    replacements:
+      maxRecords: '20'
+  -
+    query: History
+    position: 5
+    subject_uri: "http://id.loc.gov/authorities/subjects/sh85061212"
+    replacements:
+      maxRecords: '20'
+  -
+    query: History
+    position: 5
+    subject_uri: "http://id.loc.gov/authorities/subjects/sh85061212"
+    replacements:
+      maxRecords: '20'
+term:
+  -
+    identifier: 'http://id.loc.gov/authorities/subjects/sh2003008312'


### PR DESCRIPTION
update authorities
* add authority configs for LOC using the new indexing approach (auth name match: loc*_new_ld4l_cache)
* sync auth configs with changes made in LD4P/qa_server
* add extended context definitions for getty aat and tgn