### PR TITLE
release 5.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 5.8.0 (2020-11-06)
+
+* add 48 small LOC vocabs (e.g. carriers, content_types, etc)
+* add extended context for getty aat and tgn
+* fix validations where results are returned but are too small
+* sync auth configs and validations with ld4p/qa_server templates
+* temporarily add new_cache auths testing new indexing scheme
+
 ### 5.7.0 (2020-09-24)
 
 * add local subauthorities property_attribute and property_type

--- a/config/authorities/linked_data/scenarios/cerl_new_ld4l_cache_validation.yml
+++ b/config/authorities/linked_data/scenarios/cerl_new_ld4l_cache_validation.yml
@@ -25,16 +25,16 @@ search:
   #  Accuracy tests
   #------------------
   -
-    query: Joannes Philippus de Lignamine
+    query: Johannes Philippus de Lignamine
     subauth: person
-    position: 1
+    position: 4
     subject_uri: "http://thesaurus.cerl.org/record/cnp00372755"
     replacements:
       maxRecords: '8'
   -
-    query: Joannes Philippus de Lignamine
+    query: Johannes Philippus de Lignamine
     subauth: person
-    position: 2
+    position: 4
     subject_uri: "http://thesaurus.cerl.org/record/cnp00895966"
     replacements:
       maxRecords: '8'

--- a/config/authorities/linked_data/scenarios/getty_tgn_new_ld4l_cache_validation.yml
+++ b/config/authorities/linked_data/scenarios/getty_tgn_new_ld4l_cache_validation.yml
@@ -14,27 +14,27 @@ search:
   -
     query: Gouverneur
     position: 3
-    subject_uri: "http://vocab.getty.edu/tgn/2069433"
+    subject_uri: "http://vocab.getty.edu/tgn/2069433-place"
     replacements:
       maxRecords: '10'
   -
     query: Boulder, CO
     position: 9
-    subject_uri: "http://vocab.getty.edu/tgn/2000198"
+    subject_uri: "http://vocab.getty.edu/tgn/2000198-place"
     replacements:
       maxRecords: '10'
   -
     query: Paris, France
     position: 30
-    subject_uri: "http://vocab.getty.edu/tgn/7008038"
+    subject_uri: "http://vocab.getty.edu/tgn/7008038-place"
     replacements:
       maxRecords: '100'
   -
     query: Nile River
     position: 3
-    subject_uri: "http://vocab.getty.edu/tgn/1127805"
+    subject_uri: "http://vocab.getty.edu/tgn/1127805-place"
     replacements:
       maxRecords: '10'
 term:
   -
-    identifier: 'http://vocab.getty.edu/tgn/7017750'
+    identifier: 'http://vocab.getty.edu/tgn/7017750-place'

--- a/config/authorities/linked_data/scenarios/locgenres_new_ld4l_cache_validation.yml
+++ b/config/authorities/linked_data/scenarios/locgenres_new_ld4l_cache_validation.yml
@@ -117,10 +117,10 @@ search:
   -
     query: Cookery
     subauth: deprecated
-    position: 10
-    subject_uri: "http://id.loc.gov/authorities/subjects/sh2010025047"
+    position: 5
+    subject_uri: "http://id.loc.gov/authorities/genreForms/gf2011026169"
     replacements:
-      maxRecords: '20'
+      maxRecords: '10'
 term:
   -
     identifier: "http://id.loc.gov/authorities/genreForms/gf2011026141"

--- a/config/authorities/linked_data/scenarios/locnames_new_ld4l_cache_validation.yml
+++ b/config/authorities/linked_data/scenarios/locnames_new_ld4l_cache_validation.yml
@@ -48,6 +48,13 @@ search:
     replacements:
       maxRecords: '15'
   -
+    query: Chicago, Ill
+    position: 5
+    subauth: geographic
+    subject_uri: "http://id.loc.gov/authorities/names/n78086438"
+    replacements:
+      maxRecords: '15'
+  -
     query: seattle
     position: 5
     subauth: geographic

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   qa_server:
-    application_version: "5.7.0"
+    application_version: "5.8.0"
     application_name:  "LD4P Authority Lookup Service"
     footer:
       copyright_html:  "<strong>Copyright &copy; 2018-2020 Cornell</strong> Licensed under the Apache License, Version 2.0"


### PR DESCRIPTION
* add 48 small LOC vocabs (e.g. carriers, content_types, etc)
* add extended context for getty aat and tgn
* fix validations where results are returned but are too small
* sync auth configs and validations with ld4p/qa_server templates
* temporarily add new_cache auths testing new indexing scheme

Also, syncs old and new validations so the new ones have the latest fixes.