### PR TITLE
tweak validation tests

### DIFF
--- a/config/authorities/linked_data/scenarios/geonames_ld4l_cache_validation.yml
+++ b/config/authorities/linked_data/scenarios/geonames_ld4l_cache_validation.yml
@@ -63,7 +63,7 @@ search:
   #    all
   -
     pending: true
-    query: New York
+    query: New York City
     subject_uri: "http://sws.geonames.org/5128581/"
     position: 3
     replacements:

--- a/config/authorities/linked_data/scenarios/getty_ulan_ld4l_cache_validation.yml
+++ b/config/authorities/linked_data/scenarios/getty_ulan_ld4l_cache_validation.yml
@@ -21,21 +21,21 @@ search:
   #------------------
   -
     query: Gonzalez-Torres, Felix
-    subject_uri: "http://vocab.getty.edu/ulan/500114715"
+    subject_uri: "http://vocab.getty.edu/ulan/500114715-agent"
     position: 5
     replacements:
       maxRecords: '10'
   -
     query: Gouverneur
     subauth: person
-    subject_uri: "http://vocab.getty.edu/ulan/500225342"
+    subject_uri: "http://vocab.getty.edu/ulan/500225342-agent"
     position: 5
     replacements:
       maxRecords: '10'
   -
     query: Octavio Medellin
     subauth: person
-    subject_uri: "http://vocab.getty.edu/ulan/500333005"
+    subject_uri: "http://vocab.getty.edu/ulan/500333005-agent"
     position: 3
     replacements:
       maxRecords: '8'
@@ -43,10 +43,10 @@ search:
     query: University of Chicago Library
     subauth: organization
     result_size: 100
-    subject_uri: "http://vocab.getty.edu/ulan/500304715"
+    subject_uri: "http://vocab.getty.edu/ulan/500304715-agent"
     position: 5
     replacements:
       maxRecords: '10'
 term:
   -
-    identifier: 'http://vocab.getty.edu/ulan/500020427'
+    identifier: 'http://vocab.getty.edu/ulan/500020427-agent'

--- a/config/authorities/linked_data/scenarios/locnames_ld4l_cache_validation.yml
+++ b/config/authorities/linked_data/scenarios/locnames_ld4l_cache_validation.yml
@@ -40,7 +40,7 @@ search:
     query: Camden NJ
     position: 8
     subauth: geographic
-    subject_uri: "http://id.loc.gov/authorities/names/n81139356"
+    subject_uri: "http://id.loc.gov/authorities/names/n80010449"
     replacements:
       maxRecords: '20'
   -

--- a/config/authorities/linked_data/scenarios/oclcfast_ld4l_cache_validation.yml
+++ b/config/authorities/linked_data/scenarios/oclcfast_ld4l_cache_validation.yml
@@ -78,9 +78,9 @@ search:
     query: Scream
     subauth: work
     subject_uri: "http://id.worldcat.org/fast/1358031"
-    position: 5
+    position: 10
     replacements:
-      maxRecords: '10'
+      maxRecords: '20'
 
 term:
   -


### PR DESCRIPTION
* geonames - New York City
* getty_ulan - URIs end in `-agent` to match RWO URI
* locnames - fix URI expected for Camden NJ
* oclcfast - loosen expectations on Scream