### PR TITLE
use madsrdf:authoritativeLabel for prefLabel

### DIFF
--- a/config/authorities/linked_data/locnames_rwo2_new_ld4l_cache.json
+++ b/config/authorities/linked_data/locnames_rwo2_new_ld4l_cache.json
@@ -86,7 +86,7 @@
     "total_count_ldpath": "vivo:count",
     "results": {
       "id_ldpath":    "^madsrdf:identifiesRWO/loc:lccn ::xsd:string",
-      "label_ldpath": "rdfs:label ::xsd:string",
+      "label_ldpath": "^madsrdf:identifiesRWO/madsrdf:authoritativeLabel ::xsd:string",
       "sort_ldpath":  "vivo:rank ::xsd:string"
     },
     "context": {
@@ -103,8 +103,8 @@
       "properties": [
         {
           "property_label_default": "Preferred label",
-          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.type_label",
-          "ldpath": "rdfs:label :: xsd:string",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.preferred_label",
+          "ldpath": "^madsrdf:identifiesRWO / madsrdf:authoritativeLabel :: xsd:string",
           "selectable": true,
           "drillable": false
         },
@@ -117,7 +117,7 @@
         },
         {
           "property_label_default": "Descriptor",
-          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.type_label",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.descriptor",
           "ldpath": "(madsrdf:entityDescriptor/madsrdf:authoritativeLabel) | (madsrdf:entityDescriptor/skos:prefLabel) | (madsrdf:entityDescriptor/rdfs:label) :: xsd:string",
           "selectable": false,
           "drillable": false,

--- a/config/authorities/linked_data/locnames_rwo3_new_ld4l_cache.json
+++ b/config/authorities/linked_data/locnames_rwo3_new_ld4l_cache.json
@@ -86,7 +86,7 @@
     "total_count_ldpath": "vivo:count",
     "results": {
       "id_ldpath":    "^madsrdf:identifiesRWO/loc:lccn ::xsd:string",
-      "label_ldpath": "rdfs:label ::xsd:string",
+      "label_ldpath": "^madsrdf:identifiesRWO/madsrdf:authoritativeLabel ::xsd:string",
       "sort_ldpath":  "vivo:rank ::xsd:string"
     },
     "context": {
@@ -103,8 +103,8 @@
       "properties": [
         {
           "property_label_default": "Preferred label",
-          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.type_label",
-          "ldpath": "rdfs:label :: xsd:string",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.preferred_label",
+          "ldpath": "^madsrdf:identifiesRWO / madsrdf:authoritativeLabel :: xsd:string",
           "selectable": true,
           "drillable": false
         },
@@ -117,7 +117,7 @@
         },
         {
           "property_label_default": "Descriptor",
-          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.type_label",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.descriptor",
           "ldpath": "(madsrdf:entityDescriptor/madsrdf:authoritativeLabel) | (madsrdf:entityDescriptor/skos:prefLabel) | (madsrdf:entityDescriptor/rdfs:label) :: xsd:string",
           "selectable": false,
           "drillable": false,

--- a/config/authorities/linked_data/locnames_rwo_new_ld4l_cache.json
+++ b/config/authorities/linked_data/locnames_rwo_new_ld4l_cache.json
@@ -86,7 +86,7 @@
     "total_count_ldpath": "vivo:count",
     "results": {
       "id_ldpath":    "^madsrdf:identifiesRWO/loc:lccn ::xsd:string",
-      "label_ldpath": "rdfs:label ::xsd:string",
+      "label_ldpath": "^madsrdf:identifiesRWO/madsrdf:authoritativeLabel ::xsd:string",
       "sort_ldpath":  "vivo:rank ::xsd:string"
     },
     "context": {
@@ -103,8 +103,8 @@
       "properties": [
         {
           "property_label_default": "Preferred label",
-          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.type_label",
-          "ldpath": "rdfs:label :: xsd:string",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.preferred_label",
+          "ldpath": "^madsrdf:identifiesRWO / madsrdf:authoritativeLabel :: xsd:string",
           "selectable": true,
           "drillable": false
         },
@@ -117,7 +117,7 @@
         },
         {
           "property_label_default": "Descriptor",
-          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.type_label",
+          "property_label_i18n": "qa.linked_data.authority.locnames_ld4l_cache.descriptor",
           "ldpath": "(madsrdf:entityDescriptor/madsrdf:authoritativeLabel) | (madsrdf:entityDescriptor/skos:prefLabel) | (madsrdf:entityDescriptor/rdfs:label) :: xsd:string",
           "selectable": false,
           "drillable": false,

--- a/config/authorities/linked_data/scenarios/locnames_rwo3_new_ld4l_cache_validation.yml
+++ b/config/authorities/linked_data/scenarios/locnames_rwo3_new_ld4l_cache_validation.yml
@@ -63,6 +63,7 @@ search:
   -
     query: Waterman Family
     subauth: family
+    result_size: 110
     position: 5
     subject_uri: "http://id.loc.gov/rwo/agents/n2012043300"
     replacements:


### PR DESCRIPTION
May need to change this based on preferred resolution for [LD4P/qa_server Issue #421](https://github.com/LD4P/qa_server/issues/421).  For now, this restores the display of the primary label.