### PR TITLE
release 6.0.0 - support new indexing approach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 6.0.0 (2021-04-12)
+
+* update to qa_server v7.6.0 - allows for use of Rails 6
+* sync authority configs and validations with definitions in LD4P/qa_server
+* many updates to configs and validations based on changes for new indexing approach
+* update to Rails 5.2.5 to fix mimemagic gem yank
+* update dependencies
+
 ### 5.9.2 (2021-01-29)
 
 * sync validation tests with LD4P/qa_server

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'dotenv-deployment'
 gem 'dotenv-rails'
 
 # Required gems for QA and linked data access
-gem 'qa_server', '~> 7.5'
+gem 'qa_server', '~> 7.6'
 gem 'qa', '~> 5.5'
 gem 'linkeddata'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ GEM
     faraday (1.1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
-    ffi (1.13.1)
+    ffi (1.15.0)
     geocoder (1.6.4)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -220,9 +220,9 @@ GEM
       nokogiri (~> 1.6)
       rails (>= 5.0, < 6.1)
       rdf
-    qa_server (7.5.1)
+    qa_server (7.6.0)
       gruff
-      rails (~> 5.0)
+      rails (~> 5.2, >= 5.2.5)
       sass-rails (~> 5.0)
       useragent
     racc (1.5.2)
@@ -319,7 +319,7 @@ GEM
       rdf (~> 3.1)
     request_store (1.5.0)
       rack (>= 1.4)
-    rmagick (4.1.2)
+    rmagick (4.2.2)
     rspec-activemodel-mocks (1.1.0)
       activemodel (>= 3.0)
       activesupport (>= 3.0)
@@ -455,7 +455,7 @@ DEPENDENCIES
   mysql2
   puma (~> 4.3)
   qa (~> 5.5)
-  qa_server (~> 7.5)
+  qa_server (~> 7.6)
   rails (~> 5.2)
   rails-controller-testing
   rspec-activemodel-mocks

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   qa_server:
-    application_version: "5.9.2"
+    application_version: "6.0.0"
     application_name:  "LD4P Authority Lookup Service"
     footer:
       copyright_html:  "<strong>Copyright &copy; 2018-2020 Cornell</strong> Licensed under the Apache License, Version 2.0"


### PR DESCRIPTION
* update to qa_server v7.6.0 - allows for use of Rails 6
* sync authority configs and validations with definitions in LD4P/qa_server
* many updates to configs and validations based on changes for new indexing approach
* update to Rails 5.2.5 to fix mimemagic gem yank
* update dependencies