### PR TITLE
release v6.1.0 - UI improvement for Monitor Status page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### 6.1.0 (2021-04-13)
+
+* update to LD4P/qa_server 7.7.0
+  * remove unused translations
+  * show notification when refreshing starts on monitor status page
+  * hide data in Authority Connection History for non-active authorities
+  * loosen threshold for caution in historical uptime table
+  * minor tweaks missed in original sync
+
 ### 6.0.0 (2021-04-12)
 
 * update to qa_server v7.6.0 - allows for use of Rails 6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,7 +220,7 @@ GEM
       nokogiri (~> 1.6)
       rails (>= 5.0, < 6.1)
       rdf
-    qa_server (7.6.0)
+    qa_server (7.7.0)
       gruff
       rails (~> 5.2, >= 5.2.5)
       sass-rails (~> 5.0)

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   qa_server:
-    application_version: "6.0.0"
+    application_version: "6.1.0"
     application_name:  "LD4P Authority Lookup Service"
     footer:
       copyright_html:  "<strong>Copyright &copy; 2018-2020 Cornell</strong> Licensed under the Apache License, Version 2.0"


### PR DESCRIPTION
* update to LD4P/qa_server 7.7.0
  * remove unused translations
  * show notification when refreshing starts on monitor status page
  * hide data in Authority Connection History for non-active authorities
  * loosen threshold for caution in historical uptime table
  * minor tweaks missed in original sync