### PR TITLE
release 6.1.3 - update Spain test to search geographic subauth for MeSH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 6.1.3 (2021-04-14)
+
+* update Spain test to search geographic subauth for MeSH (NLM)
+
 ### 6.1.2 (2021-04-14)
 
 * add geographic subauth for MeSH (NLM)

--- a/config/authorities/linked_data/scenarios/mesh_nlm_ld4l_cache_validation.yml
+++ b/config/authorities/linked_data/scenarios/mesh_nlm_ld4l_cache_validation.yml
@@ -45,7 +45,7 @@ search:
   -
     pending: true
     query: Spain
-    subauth: subject
+    subauth: geographic
     subject_uri: "http://id.nlm.nih.gov/mesh/D013030"
     position: 3
     replacements:

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   qa_server:
-    application_version: "6.1.2"
+    application_version: "6.1.3"
     application_name:  "LD4P Authority Lookup Service"
     footer:
       copyright_html:  "<strong>Copyright &copy; 2018-2020 Cornell</strong> Licensed under the Apache License, Version 2.0"


### PR DESCRIPTION
Release v6.1.3
* adds geographic subauth for MeSH-NLM
* updates Spain test to search geographic subauth for MeSH
