### PR TITLE
release 6.3.0 - up-down connection chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 6.3.0 (2021-04-16)
+
+* update to LD4P/qa_server 7.9.0
+  * Add chart showing simulated graph (in table) of the last 30 days of up-down connection data
+
 ### 6.2.0 (2021-04-14)
 
 * update to LD4P/qa_server 7.8.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,7 +220,7 @@ GEM
       nokogiri (~> 1.6)
       rails (>= 5.0, < 6.1)
       rdf
-    qa_server (7.8.0)
+    qa_server (7.9.0)
       gruff
       rails (~> 5.2, >= 5.2.5)
       sass-rails (~> 5.0)

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   qa_server:
-    application_version: "6.2.0"
+    application_version: "6.3.0"
     application_name:  "LD4P Authority Lookup Service"
     footer:
       copyright_html:  "<strong>Copyright &copy; 2018-2020 Cornell</strong> Licensed under the Apache License, Version 2.0"


### PR DESCRIPTION
* Add chart showing simulated graph (in table) of the last 30 days of up-down connection data