### PR TITLE
release 6.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 6.4.0 (2021-10-12)
+
+* add publisher cities select list
+* add fix for bundler install on elastic beanstalk
+* update dependencies
+
 ### 6.3.1 (2021-06-10)
 
 * update to LD4P/qa_server 7.9.2

--- a/config/locales/qa_server.en.yml
+++ b/config/locales/qa_server.en.yml
@@ -1,9 +1,9 @@
 ---
 en:
   qa_server:
-    application_version: "6.3.1"
+    application_version: "6.4.0"
     application_name:  "LD4P Authority Lookup Service"
     footer:
-      copyright_html:  "<strong>Copyright &copy; 2018-2020 Cornell</strong> Licensed under the Apache License, Version 2.0"
+      copyright_html:  "<strong>Copyright &copy; 2018-2021 Cornell</strong> Licensed under the Apache License, Version 2.0"
       service_html:    A service of <a href="http://www.library.cornell.edu/" class="navbar-link" target="_blank">Cornell University Library</a> and <br /><a href="https://www.slis.uiowa.edu/" class="navbar-link" target="_blank">School of Library and Information Science, University of Iowa</a>.
       attribution_html: This service is supported by work on <a href="http://ld4l.org" class="navbar-link" target="_blank">Linked Data for Libraries - Labs</a> and <br>  <a href="https://wiki.duraspace.org/x/9xgRBg" class="navbar-link" target="_blank">Linked Data for Production</a> funded by <a href="https://mellon.org/" class="navbar-link" target="_blank">Andrew W. Mellon Foundation</a>, <br>and by work on Questioning Authority in <a href="http://samvera.org" class="navbar-link" target="_blank">Samvera</a>, an open source community.


### PR DESCRIPTION
### 6.4.0 (2021-10-12)

* add publisher cities select list
* add fix for bundler install on elastic beanstalk
* update dependencies