### PR TITLE
Revert "Bump nokogiri from 1.12.5 to 1.13.2"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-gem 'nokogiri', '~> 1.13' ### TEMPORARY PIN 1.13 requires ruby > 2.5
+gem 'nokogiri', '~> 1.12', '< 1.13' ### TEMPORARY PIN 1.13 requires ruby > 2.5
 
 gem 'rails', '~> 5.2'
 gem 'dotenv-deployment'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,9 +230,7 @@ GEM
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
     nio4r (2.5.8)
-    nokogiri (1.13.2-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.13.2-x86_64-linux)
+    nokogiri (1.12.5-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.12.5-x86_64-linux)
       racc (~> 1.4)
@@ -483,7 +481,6 @@ GEM
 
 PLATFORMS
   x86_64-darwin-18
-  x86_64-linux
 
 DEPENDENCIES
   better_errors
@@ -503,7 +500,7 @@ DEPENDENCIES
   listen
   lograge
   mysql2
-  nokogiri (~> 1.13)
+  nokogiri (~> 1.12, < 1.13)
   puma (~> 4.3)
   qa (~> 5.5)
   qa_server (~> 7.9)


### PR DESCRIPTION
Reverts cul-it/qa_server#335

Prior to #335, nokogiri was pinned to '< 1.13' which requires ruby '> 2.5'.

qa_server does not use the reported vulnerability, so reinstating the pin until ruby can be updated.